### PR TITLE
Disable cancel delete events

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 The Graph
+Copyright (c) 2020 Gnosis Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/subgraph.yaml.mustache
+++ b/subgraph.yaml.mustache
@@ -56,6 +56,8 @@ dataSources:
         # Orders
         - event: OrderPlacement(indexed address,uint16,indexed uint16,indexed uint16,uint32,uint32,uint128,uint128)
           handler: onOrderPlacement
+        
+        # FIXME: Uncomment when this issue is solved https://github.com/gnosis/dex-subgraph/issues/9
         #- event: OrderCancellation(indexed address,uint16)
         #  handler: onOrderCancellation
         #- event: OrderDeletion(indexed address,uint16)

--- a/subgraph.yaml.mustache
+++ b/subgraph.yaml.mustache
@@ -56,10 +56,10 @@ dataSources:
         # Orders
         - event: OrderPlacement(indexed address,uint16,indexed uint16,indexed uint16,uint32,uint32,uint128,uint128)
           handler: onOrderPlacement
-        - event: OrderCancellation(indexed address,uint16)
-          handler: onOrderCancellation
-        - event: OrderDeletion(indexed address,uint16)
-          handler: onOrderDeletion
+        #- event: OrderCancellation(indexed address,uint16)
+        #  handler: onOrderCancellation
+        #- event: OrderDeletion(indexed address,uint16)
+        #  handler: onOrderDeletion
         
         # Trades
         - event: Trade(indexed address,indexed uint16,indexed uint16,uint16,uint128,uint128)


### PR DESCRIPTION
This change was the temporal fix that we apply to mainnet graph to make it work (see #9)

I asked for help in The graph channel, and although Dave tried to help, he didn't find the issue.
We'll ask again and try to come up to how to reproduce this in local, but for now, I would like to leave this PR applied in master, and referencing it to the issue so we have a commit to revert once it's fixed.

Conversation regarding this:
https://gnosisinc.slack.com/archives/CGMAENMEH/p1583573568011500