### PR TITLE
Fix price issue

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -36,7 +36,8 @@ type Price @entity {
   batchId: BigInt!
 
   # Price and volume
-  priceInOwl: BigInt!
+  priceInOwlNumerator: BigInt!
+  priceInOwlDenominator: BigInt!
   volume: BigInt!
 
   # Audit Dates

--- a/src/mappings/prices.ts
+++ b/src/mappings/prices.ts
@@ -5,7 +5,7 @@ import { toPriceId, getOwlDecimals, calculatePrice, toWei } from '../utils'
 import { BatchExchange } from '../../generated/BatchExchange/BatchExchange'
 import { getTokenById } from './tokens'
 
-let ONE_WEI = toWei(BigInt.fromI32(1), BigInt.fromI32(18))
+let EXA_AMOUNT = toWei(BigInt.fromI32(1), BigInt.fromI32(18))
 
 export function createOrUpdatePrice(tokenId: i32, trade: Trade, event: EthereumEvent): void {
   log.info('[createOrUpdatePrice] Create or Update Price for batch {} and Token {}. Tx: ', [
@@ -38,16 +38,7 @@ export function _createPrice(priceId: string, tokenId: i32, trade: Trade, event:
   // Add token
   price.token = BigInt.fromI32(tokenId).toString()
 
-  // Price: Calculate price in user friendly format
-  //   The price in the contract is recorded in an internal format that would be something like:
-  //        ("sell token in weis" / 1 OWL) * 1e18
-  //   We need to calculate the price in a user friendly format, a fraction with units:
-  //        "sell token" / OWL
-  let batchExchange = BatchExchange.bind(event.address)
-  let token = getTokenById(tokenId)
-  let weisOfTokenForOneOwl = batchExchange.currentPrices(tokenId)
-
-  let priceInOwl = calculatePrice(weisOfTokenForOneOwl, token.decimals, ONE_WEI, getOwlDecimals())
+  let priceInOwl = _getPriceInOwl(tokenId, event)
   price.priceInOwlNumerator = priceInOwl[0]
   price.priceInOwlDenominator = priceInOwl[1]
 
@@ -62,4 +53,41 @@ export function _createPrice(priceId: string, tokenId: i32, trade: Trade, event:
 
   price.save()
   return price
+}
+
+/**
+  The price in the contract is recorded in an internal format that would be something like:
+         "sell token in weis" / 1e18 OWLs
+         
+  We need to calculate the price in a user friendly format, a fraction with units:
+         "sell token" / OWL
+
+  i.e. For USDC wich has 6 decimals can return 980942729992317873036301363769, meaning:
+      The units of this big number (980942729992317873036301363769) is:
+          "OWL wei / exa USDC wei"
+        or in other words:
+          "weis of OWL by each 1e18 weis of USDC"
+        
+        Yes! it's confusing, but let's just explain it backwards:
+
+        980942729992317873036301363769 * <something> = 0.98094273 USDC/OWL
+            --> <something> = 1e-30 = 1e-18 * 1e-18 * 1e6
+            
+          [price * 1e-18 * 1e-18 * 1e6 ] USDC / OWL
+          [price * 1e-18 * 1e-18 ] USDC * 1e6 / OWL
+          [price * 1e-18 * 1e-18 ] USDC wei / OWL
+          [price * 1e-18  ] USDC wei / OWL * 1e18
+          [price * 1e-18 ] USDC wei / OWL wei
+          [price] exa USDC wei / OWL wei
+ */
+function _getPriceInOwl(tokenId: i32, event: EthereumEvent): BigInt[] {
+  // Price: Calculate price in user friendly format
+
+  let batchExchange = BatchExchange.bind(event.address)
+  let token = getTokenById(tokenId)
+
+  // Excuse the name of the var name, but it tries to represent what the contract returns
+  let weisOfTokenPerExaWeiOfOwl = batchExchange.currentPrices(tokenId)
+
+  return calculatePrice(EXA_AMOUNT, getOwlDecimals(), weisOfTokenPerExaWeiOfOwl, token.decimals)
 }

--- a/src/mappings/prices.ts
+++ b/src/mappings/prices.ts
@@ -1,9 +1,11 @@
 import { log, BigInt } from '@graphprotocol/graph-ts'
 import { Price, Trade } from '../../generated/schema'
 import { EthereumEvent } from '@graphprotocol/graph-ts'
-import { toPriceId, getOwlDecimals, toPriceInUnits } from '../utils'
+import { toPriceId, getOwlDecimals, calculatePrice, toWei } from '../utils'
 import { BatchExchange } from '../../generated/BatchExchange/BatchExchange'
 import { getTokenById } from './tokens'
+
+let ONE_WEI = toWei(BigInt.fromI32(1), BigInt.fromI32(18))
 
 export function createOrUpdatePrice(tokenId: i32, trade: Trade, event: EthereumEvent): void {
   log.info('[createOrUpdatePrice] Create or Update Price for batch {} and Token {}. Tx: ', [
@@ -33,14 +35,21 @@ export function _createPrice(priceId: string, tokenId: i32, trade: Trade, event:
   let price = new Price(priceId)
   price.batchId = trade.tradeBatchId
 
-  // Addd token
+  // Add token
   price.token = BigInt.fromI32(tokenId).toString()
 
-  // Price: The price is given in weis of the token per owl, so it needs to be translated into tokens per owl
+  // Price: Calculate price in user friendly format
+  //   The price in the contract is recorded in an internal format that would be something like:
+  //        ("sell token in weis" / 1 OWL) * 1e18
+  //   We need to calculate the price in a user friendly format, a fraction with units:
+  //        "sell token" / OWL
   let batchExchange = BatchExchange.bind(event.address)
   let token = getTokenById(tokenId)
   let priceInWeis = batchExchange.currentPrices(tokenId)
-  price.priceInOwl = toPriceInUnits(priceInWeis, token.decimals, getOwlDecimals())
+
+  let priceInOwl = calculatePrice(priceInWeis, ONE_WEI, token.decimals, getOwlDecimals())
+  price.priceInOwlNumerator = priceInOwl[0]
+  price.priceInOwlDenominator = priceInOwl[1]
 
   // Volume
   price.volume = BigInt.fromI32(0)

--- a/src/mappings/prices.ts
+++ b/src/mappings/prices.ts
@@ -45,9 +45,9 @@ export function _createPrice(priceId: string, tokenId: i32, trade: Trade, event:
   //        "sell token" / OWL
   let batchExchange = BatchExchange.bind(event.address)
   let token = getTokenById(tokenId)
-  let priceInWeis = batchExchange.currentPrices(tokenId)
+  let weisOfTokenForOneOwl = batchExchange.currentPrices(tokenId)
 
-  let priceInOwl = calculatePrice(priceInWeis, ONE_WEI, token.decimals, getOwlDecimals())
+  let priceInOwl = calculatePrice(weisOfTokenForOneOwl, token.decimals, ONE_WEI, getOwlDecimals())
   price.priceInOwlNumerator = priceInOwl[0]
   price.priceInOwlDenominator = priceInOwl[1]
 

--- a/src/mappings/tokens.ts
+++ b/src/mappings/tokens.ts
@@ -41,6 +41,15 @@ export function createTokenIfNotCreated(tokenId: u32, event: EthereumEvent): Tok
   return token!
 }
 
+export function getTokenById(tokenId: i32): Token {
+  let id = BigInt.fromI32(tokenId).toString()
+  let tokenOpt = Token.load(id)
+  if (!tokenOpt) {
+    throw new Error("Order doesn't exist: " + id)
+  }
+  return tokenOpt!
+}
+
 export function _createToken(id: string, address: Address, timestamp: BigInt, txHash: Bytes): Token {
   log.info('[createToken] Create Token {} with address {}', [id, address.toHex()])
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,6 +64,20 @@ export function reduce(numerator: BigInt, denominator: BigInt): BigInt[] {
   return [numerator.div(greatestCommonDenominator), denominator.div(greatestCommonDenominator)]
 }
 
+/**
+ * Calculate the price given twe amounts of two tokens
+ *
+ * For the market Orange-Apple, we say:
+ *   - Orange is the base currency
+ *   - Apple is the quote currency
+ *   - And the price would be, how many Apples you pay for one Orange
+ *
+ *
+ * @param amountBase Amount in the base token
+ * @param decimalsBaseOpt
+ * @param amountQuote
+ * @param decimalsQuoteOpt
+ */
 export function calculatePrice(
   amountBase: BigInt,
   decimalsBaseOpt: BigInt | null,
@@ -74,12 +88,12 @@ export function calculatePrice(
   let decimalsQuote = coalesce<BigInt>(decimalsQuoteOpt, DEFAULT_DECIMALS)
   let decimalsDifference = decimalsBase.minus(decimalsQuote)
 
-  log.info('[utils:calculatePrice] Base: {} ({}) and Quote: {} ({})', [
-    amountBase.toString(),
-    decimalsBase.toString(),
-    amountQuote.toString(),
-    decimalsQuote.toString(),
-  ])
+  // log.info('[utils:calculatePrice] Base: {} ({}) and Quote: {} ({})', [
+  //   amountBase.toString(),
+  //   decimalsBase.toString(),
+  //   amountQuote.toString(),
+  //   decimalsQuote.toString(),
+  // ])
 
   let priceNumerator: BigInt
   let priceDenominator: BigInt

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { Address, BigInt, EthereumEvent, EthereumCall } from '@graphprotocol/graph-ts'
 
 let BATCH_TIME = BigInt.fromI32(300)
+let OWL_DECIMALS = BigInt.fromI32(18)
 
 export function toOrderId(ownerAddress: Address, orderId: i32): string {
   return ownerAddress.toHex() + '-' + BigInt.fromI32(orderId).toString()
@@ -28,4 +29,8 @@ export function epochToBatchId(epoch: BigInt): BigInt {
 
 export function getBatchId(event: EthereumEvent): BigInt {
   return epochToBatchId(event.block.timestamp)
+}
+
+export function getOwlDecimals(): BigInt {
+  return OWL_DECIMALS
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,8 @@ import { Address, BigInt, EthereumEvent, EthereumCall } from '@graphprotocol/gra
 
 let BATCH_TIME = BigInt.fromI32(300)
 let OWL_DECIMALS = BigInt.fromI32(18)
+let DEFAULT_DECIMALS = BigInt.fromI32(18)
+let TEN = BigInt.fromI32(10)
 
 export function toOrderId(ownerAddress: Address, orderId: i32): string {
   return ownerAddress.toHex() + '-' + BigInt.fromI32(orderId).toString()
@@ -41,4 +43,11 @@ export function coalesce<T>(valueOpt: T | null, defaultValue: T): T {
   } else {
     return valueOpt!
   }
+}
+
+export function toPriceInUnits(price: BigInt, decimalsBaseOpt: BigInt | null, decimalsQuoteOpt: BigInt | null): BigInt {
+  let decimalsBase = coalesce<BigInt>(decimalsBaseOpt, DEFAULT_DECIMALS).toI32()
+  let decimalsQuote = coalesce<BigInt>(decimalsQuoteOpt, DEFAULT_DECIMALS).toI32()
+
+  return price.div(TEN.pow(u8(decimalsBase - decimalsQuote)))
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,9 +45,29 @@ export function coalesce<T>(valueOpt: T | null, defaultValue: T): T {
   }
 }
 
-export function toPriceInUnits(price: BigInt, decimalsBaseOpt: BigInt | null, decimalsQuoteOpt: BigInt | null): BigInt {
+export function toWei(amount: BigInt, decimalsOpt: BigInt | null): BigInt {
+  let decimals = coalesce<BigInt>(decimalsOpt, DEFAULT_DECIMALS).toI32()
+  return amount.times(TEN.pow(u8(decimals)))
+}
+
+export function calculatePrice(
+  priceNumerator: BigInt,
+  priceDenominator: BigInt,
+  decimalsBaseOpt: BigInt | null,
+  decimalsQuoteOpt: BigInt | null,
+): BigInt[] {
   let decimalsBase = coalesce<BigInt>(decimalsBaseOpt, DEFAULT_DECIMALS).toI32()
   let decimalsQuote = coalesce<BigInt>(decimalsQuoteOpt, DEFAULT_DECIMALS).toI32()
 
-  return price.div(TEN.pow(u8(decimalsBase - decimalsQuote)))
+  let newNumerator: BigInt
+  let newDenominator: BigInt
+  if (decimalsBase > decimalsQuote) {
+    newNumerator = priceNumerator.times(TEN.pow(u8(decimalsBase - decimalsQuote)))
+    newDenominator = priceDenominator
+  } else {
+    newNumerator = priceDenominator
+    newDenominator = priceNumerator.times(TEN.pow(u8(decimalsBase - decimalsQuote)))
+  }
+
+  return [newNumerator, newDenominator]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,12 +71,6 @@ export function calculatePrice(
 ): BigInt[] {
   let decimalsBase = coalesce<BigInt>(decimalsBaseOpt, DEFAULT_DECIMALS).toI32()
   let decimalsQuote = coalesce<BigInt>(decimalsQuoteOpt, DEFAULT_DECIMALS).toI32()
-  log.info('[utils:calculatePrice] {} / {} with decimals {} and {}', [
-    priceNumerator.toString(),
-    priceDenominator.toString(),
-    BigInt.fromI32(decimalsBase).toString(),
-    BigInt.fromI32(decimalsQuote).toString(),
-  ])
 
   let newNumerator: BigInt
   let newDenominator: BigInt
@@ -91,8 +85,6 @@ export function calculatePrice(
     newNumerator = newNumerator
     newDenominator = priceDenominator.times(TEN.pow(u8(decimalsQuote - decimalsBase)))
   }
-
-  log.info('[utils:calculatePrice] {} / {}', [newNumerator.toString(), newDenominator.toString()])
 
   return reduce(newNumerator, newDenominator)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,11 @@ export function getBatchId(event: EthereumEvent): BigInt {
 export function getOwlDecimals(): BigInt {
   return OWL_DECIMALS
 }
+
+export function coalesce<T>(valueOpt: T | null, defaultValue: T): T {
+  if (valueOpt == null) {
+    return defaultValue
+  } else {
+    return valueOpt!
+  }
+}


### PR DESCRIPTION
The Price entity is saving the price in OWL that it get's from the contract.

This price is in weis and involves 2 different tokens, so if you want to express it in normal units a user might expect, we need to adjust the value using the decimals of the two tokens.

This PR address this, fixing the issue we could see already in the history price app:

![image](https://user-images.githubusercontent.com/2352112/77446954-60fc9a00-6def-11ea-9cc4-c61a9ee1f456.png)
