### PR TITLE
Incorrect price volume fixed

### DIFF
--- a/src/mappings/trades.ts
+++ b/src/mappings/trades.ts
@@ -49,7 +49,6 @@ export function onTrade(event: TradeEvent): void {
   let trade = _createTrade(orderId, event)
 
   // Update traces
-  createOrUpdatePrice(event.params.buyToken, trade, event)
   createOrUpdatePrice(event.params.sellToken, trade, event)
 
   // Update order (traded amounts totals)


### PR DESCRIPTION
Closes #54 

1. fixes sellVolume + reverse token sellVolume total vol problem

Can check via local in README that the `volume` indeed only equals the `sellVolume` of the token across trades in that `batchId`

The problem was the check for both the buyToken and sellToken amounts. They were being summed