### PR TITLE
Fix BigInt construction

### DIFF
--- a/src/mappings/orders.ts
+++ b/src/mappings/orders.ts
@@ -39,7 +39,7 @@ export function onOrderCancellation(event: OrderCancellationEvent): void {
 
   if (order.cancelEpoch == null) {
     let batchId = getBatchId(event)
-    order.untilBatchId = batchId.minus(new BigInt(1))
+    order.untilBatchId = batchId.minus(BigInt.fromI32(1))
     order.untilEpoch = batchIdToEpoch(order.untilBatchId)
     order.cancelEpoch = event.block.timestamp
     order.save()
@@ -57,7 +57,7 @@ export function onOrderDeletion(event: OrderDeletionEvent): void {
 
   if (order.deleteEpoch == null) {
     let batchId = getBatchId(event)
-    order.untilBatchId = batchId.minus(new BigInt(1))
+    order.untilBatchId = batchId.minus(BigInt.fromI32(1))
     order.untilEpoch = batchIdToEpoch(order.untilBatchId)
     order.deleteEpoch = event.block.timestamp
     order.save()

--- a/src/mappings/trades.ts
+++ b/src/mappings/trades.ts
@@ -104,7 +104,7 @@ function _createTrade(orderId: string, event: TradeEvent): Trade {
   trade.buyVolume = params.executedBuyAmount
   // Solutions are submitted always for the previous batch (not the current one)
   // For this reason, we know the trade id is the current batch minus one.
-  trade.tradeBatchId = batchId.minus(new BigInt(1))
+  trade.tradeBatchId = batchId.minus(BigInt.fromI32(1))
   trade.tradeEpoch = batchIdToEndOfBatchEpoch(batchId)
 
   // Tokens

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export function batchIdToEpoch(batchId: BigInt): BigInt {
 }
 
 export function batchIdToEndOfBatchEpoch(batchId: BigInt): BigInt {
-  return batchIdToEpoch(batchId.plus(new BigInt(1)))
+  return batchIdToEpoch(batchId.plus(BigInt.fromI32(1)))
 }
 
 export function epochToBatchId(epoch: BigInt): BigInt {


### PR DESCRIPTION
It turns out that `new BigInt(x)` creates a zero-valued `BigInt`. This PR changes all `new BigInt(x)` calls to `BigInt.fromI32(x)` so that they are created with the correct value.

Unfortunately this was not caught by the compiler.

This should fix #8 as well as fix #70

### Test Plan

This PR has been deployed to staging and we can verify that #8 is fixed:
```
$ QUERY='{"query":"{rightBatchId: batch(id: \"5271665\") {solution {txHash}} wrongBatchId: batch(id: \"5271666\") {solution {txHash}}}","variables":null}'
$ curl 'https://api.thegraph.com/subgraphs/name/gnosis/protocol' --data-raw "$QUERY"
{"data":{"rightBatchId":null,"wrongBatchId":{"solution":{"txHash":"0x9431f5e09fcdc15698880e07abf2425245ba36119e1d9a387e7a26d84acf6c2a"}}}}
$ curl 'https://api.thegraph.com/subgraphs/id/QmVWKgJpjx4ePUcmzsmdbUbxjwKkD5mG7dLGAcGPF1YHtq' --data-raw "$QUERY"
{"data":{"rightBatchId":{"solution":{"txHash":"0x9431f5e09fcdc15698880e07abf2425245ba36119e1d9a387e7a26d84acf6c2a"}},"wrongBatchId":null}}
```