### PR TITLE
Add simple Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - lts/*
+cache: yarn
+script:
+  - yarn lint
+  - yarn build


### PR DESCRIPTION
This PR adds a simple Travis CI configuration that just checks that the subgraph builds and lints. Note that the linting is currently not working, but that will be fixed in a follow-up PR.

### Test Plan

CI Passes!