### PR TITLE
Initial WebAssembly loading code

### DIFF
--- a/tests/runtime/abi.ts
+++ b/tests/runtime/abi.ts
@@ -1,0 +1,31 @@
+const LE = true
+const ENCODING = 'utf-16le'
+
+export type Pointer = number
+
+export class Abi {
+  private text = {
+    decoder: new TextDecoder(ENCODING),
+  }
+
+  constructor(private memory: WebAssembly.Memory) {}
+
+  private get heap() {
+    return new Uint8Array(this.memory.buffer)
+  }
+
+  private get view() {
+    return new DataView(this.memory.buffer)
+  }
+
+  public readString(ptr: Pointer): string | null {
+    if (ptr === 0) {
+      return null
+    }
+
+    const len = this.view.getUint32(ptr, LE)
+    const start = ptr + 4
+    const bytes = this.heap.subarray(start, start + len * 2)
+    return this.text.decoder.decode(bytes)
+  }
+}

--- a/tests/runtime/host/index.ts
+++ b/tests/runtime/host/index.ts
@@ -1,0 +1,8 @@
+export class Host {
+  public abort(message: string, fileName: string | null, line: number, column: number): void {
+    const f = fileName || '?'
+    const l = line || '?'
+    const c = column || '?'
+    throw new Error(`aborted "${message}" at ${f}, line ${l}, column ${c}`)
+  }
+}

--- a/tests/runtime/index.ts
+++ b/tests/runtime/index.ts
@@ -1,0 +1,84 @@
+/**
+ * A mock test runtime for loading the AssemblyScript mappings and marshalling
+ * test data from TypeScript/JavaScript to AssemblyScript/WebAssembly.
+ */
+
+import { promises as fs } from 'fs'
+import path from 'path'
+import { Abi } from './abi'
+import { Host } from './host'
+
+let CACHED_MODULE: Promise<WebAssembly.Module> | undefined
+
+export class Mappings {
+  private constructor(private abi: Abi, private host: Host, private instance: WebAssembly.Instance) {}
+
+  public static async load(): Promise<Mappings> {
+    const module = await (CACHED_MODULE = CACHED_MODULE || compile())
+
+    let abi: Abi | null = null
+    const host = new Host()
+    const instance = await WebAssembly.instantiate(
+      module,
+      imports(() => {
+        if (!abi) {
+          throw new Error('ABI encoder not initialized')
+        }
+        return abi
+      }, host),
+    )
+
+    abi = new Abi(instance.exports.memory as WebAssembly.Memory)
+    return new Mappings(abi, host, instance)
+  }
+
+  private handler(name: string, ...args: unknown[]): void {
+    ;(this.instance.exports[name] as (...a: unknown[]) => void)(...args)
+  }
+
+  public onAddToken(): void {
+    this.handler('onAddToken')
+  }
+}
+
+async function compile(): Promise<WebAssembly.Module> {
+  const modulePath = path.join(__dirname, '../../build/BatchExchange/BatchExchange.wasm')
+  const buffer = await fs.readFile(modulePath)
+  return WebAssembly.compile(buffer)
+}
+
+function imports(abi: () => Abi, host: Host): WebAssembly.Imports {
+  const nonnull = <T>(value: T | null | undefined) => {
+    if (value === null || value === undefined) {
+      throw new Error('unexpected null WebAssembly value')
+    }
+    return value
+  }
+  const todo = () => {
+    throw new Error('not implemented')
+  }
+
+  return {
+    env: {
+      abort: (message: number, fileName: number, line: number, column: number) => {
+        host.abort(nonnull(abi().readString(message)), abi().readString(fileName), line, column)
+      },
+    },
+    index: {
+      'bigInt.dividedBy': todo,
+      'bigInt.minus': todo,
+      'bigInt.mod': todo,
+      'bigInt.plus': todo,
+      'bigInt.pow': todo,
+      'bigInt.times': todo,
+      'log.log': todo,
+      'store.get': todo,
+      'store.set': todo,
+      'typeConversion.bigIntToString': todo,
+      'typeConversion.bytesToHex': todo,
+    },
+    ethereum: {
+      'ethereum.call': todo,
+    },
+  }
+}

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
+import { Mappings } from './runtime'
 
-describe('something', function () {
-  it('does stuff', function () {
-    const result = 21 * 2
-    expect(result).equal(42)
+describe('onAddToken', function () {
+  it('adds a new token', async () => {
+    await Mappings.load().catch((err) => expect(err.message).to.equal('not implemented'))
   })
 })


### PR DESCRIPTION
This PR adds initial code for loading the compiled subgraph WebAssembly blob.

Currently the loading fails because WebAssembly is calling some no implemented `todo` import, this will be addressed incrementally in future PRs.

### Test Plan

CI runs this code!