### PR TITLE
Marshal Ethereum events from JS to Wasm

### DIFF
--- a/tests/deposits.test.ts
+++ b/tests/deposits.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai'
+import { Mappings } from './runtime'
+
+describe('onDeposit', function () {
+  it('creates a user if it does not exist', async () => {
+    const mappings = await Mappings.load()
+
+    const user = '0x0123456789012345678901234567890123456789'
+    const tx = `0x${'42'.repeat(32)}`
+
+    expect(() => {
+      mappings.onDeposit(
+        {
+          user,
+          token: '0x0000000000000000000000000000000000000001',
+          amount: 10n ** 18n,
+          batchId: 42,
+        },
+        {
+          transactionHash: tx,
+        },
+      )
+    }).to.throw('not implemented')
+  })
+})

--- a/tests/runtime/abi.ts
+++ b/tests/runtime/abi.ts
@@ -1,3 +1,4 @@
+import { Event, Value, ValueKind } from './ethereum'
 import { fromBytesLE, toBytesLE } from './int'
 
 const LE = true
@@ -33,9 +34,17 @@ export class Abi {
     // NOTE: AssemblyScript arena allocator requires allocs to be powers of 2.
     // This is done by shifting `u32::MAX` the number of leading zeros in `size`
     // and then adding `1` to make the next power of two.
-    const nextPowerOfTwo = (0xffffffff >> Math.clz32(size - 1)) + 1
+    const nextPowerOfTwo = (0xffffffff >>> Math.clz32(size - 1)) + 1
 
     return this.allocator(nextPowerOfTwo)
+  }
+
+  private getWord(ptr: Pointer): number {
+    return this.view.getUint32(ptr, LE)
+  }
+
+  private setWord(ptr: Pointer, value: number) {
+    this.view.setUint32(ptr, value, LE)
   }
 
   public readArrayBuffer(ptr: Pointer): ArrayBuffer | null {
@@ -43,25 +52,17 @@ export class Abi {
       return null
     }
 
-    const len = this.view.getUint32(ptr, LE)
+    const len = this.getWord(ptr)
     const start = ptr + 8 // 4 bytes padding
     return this.buffer.slice(start, start + len)
   }
 
   public readBigInt(ptr: Pointer): bigint | null {
-    if (ptr === 0) {
+    const bytes = this.readUint8Array(ptr)
+    if (!bytes) {
       return null
     }
 
-    const buffer = this.readArrayBuffer(this.view.getUint32(ptr, LE))
-    if (buffer === null) {
-      throw new Error('BitInt with null buffer')
-    }
-
-    const offset = this.view.getUint32(ptr + 4, LE)
-    const len = this.view.getUint32(ptr + 8, LE)
-
-    const bytes = new Uint8Array(buffer, offset, len)
     return fromBytesLE(bytes)
   }
 
@@ -70,29 +71,173 @@ export class Abi {
       return null
     }
 
-    const len = this.view.getUint32(ptr, LE)
+    const len = this.getWord(ptr)
     const start = ptr + 4
     const bytes = this.heap.subarray(start, start + len * 2)
     return this.text.decoder.decode(bytes)
   }
 
-  public writeArrayBuffer(value: ArrayBuffer): Pointer {
-    const ptr = this.allocate(8 + value.byteLength)
+  public readUint8Array(ptr: Pointer): Uint8Array | null {
+    if (ptr === 0) {
+      return null
+    }
 
-    this.view.setUint32(ptr, value.byteLength, LE)
+    const buffer = this.readArrayBuffer(this.getWord(ptr))
+    if (buffer === null) {
+      throw new Error('Uint8Array with null buffer')
+    }
+
+    const offset = this.getWord(ptr + 4)
+    const len = this.getWord(ptr + 8)
+    const bytes = new Uint8Array(buffer, offset, len)
+
+    return bytes
+  }
+
+  private writeArray<T>(values: T[], writer: (value: T) => Pointer): Pointer {
+    const ptrs = new Uint32Array(values.length)
+    for (let i = 0; i < values.length; i++) {
+      ptrs[i] = writer(values[i])
+    }
+
+    const ptr = this.allocate(8)
+    this.setWord(ptr, this.writeArrayBuffer(ptrs.buffer))
+    this.setWord(ptr + 4, values.length)
+
+    return ptr
+  }
+
+  public writeArrayBuffer(value: ArrayBuffer | null): Pointer {
+    if (value === null) {
+      return 0
+    }
+
+    const ptr = this.allocate(8 + value.byteLength)
+    this.setWord(ptr, value.byteLength)
     this.heap.set(new Uint8Array(value), ptr + 8)
 
     return ptr
   }
 
-  public writeBigInt(value: bigint): Pointer {
+  public writeBigInt(value: bigint | null): Pointer {
+    if (value === null) {
+      return 0
+    }
     const bytes = toBytesLE(value)
-    const bufferPtr = this.writeArrayBuffer(bytes)
+    return this.writeUint8Array(bytes)
+  }
+
+  public writeEvent(value: Event | null): Pointer {
+    if (value === null) {
+      return 0
+    }
+
+    const blockPtr = this.allocate(56)
+    this.setWord(blockPtr, this.writeUint8Array(value.block.hash))
+    this.setWord(blockPtr + 4, this.writeUint8Array(value.block.parentHash))
+    this.setWord(blockPtr + 8, this.writeUint8Array(value.block.unclesHash))
+    this.setWord(blockPtr + 12, this.writeUint8Array(value.block.author))
+    this.setWord(blockPtr + 16, this.writeUint8Array(value.block.stateRoot))
+    this.setWord(blockPtr + 20, this.writeUint8Array(value.block.transactionsRoot))
+    this.setWord(blockPtr + 24, this.writeUint8Array(value.block.receiptsRoot))
+    this.setWord(blockPtr + 28, this.writeBigInt(value.block.number))
+    this.setWord(blockPtr + 32, this.writeBigInt(value.block.gasUsed))
+    this.setWord(blockPtr + 36, this.writeBigInt(value.block.gasLimit))
+    this.setWord(blockPtr + 40, this.writeBigInt(value.block.timestamp))
+    this.setWord(blockPtr + 44, this.writeBigInt(value.block.difficulty))
+    this.setWord(blockPtr + 48, this.writeBigInt(value.block.totalDifficulty))
+    this.setWord(blockPtr + 52, this.writeBigInt(value.block.size))
+
+    const txPtr = this.allocate(32)
+    this.setWord(txPtr, this.writeUint8Array(value.transaction.hash))
+    this.setWord(txPtr + 4, this.writeBigInt(value.transaction.index))
+    this.setWord(txPtr + 8, this.writeUint8Array(value.transaction.from))
+    this.setWord(txPtr + 12, this.writeUint8Array(value.transaction.to))
+    this.setWord(txPtr + 16, this.writeBigInt(value.transaction.value))
+    this.setWord(txPtr + 20, this.writeBigInt(value.transaction.gasUsed))
+    this.setWord(txPtr + 24, this.writeBigInt(value.transaction.gasPrice))
+    this.setWord(txPtr + 28, this.writeUint8Array(value.transaction.input))
+
+    const paramsPtr = this.writeArray(value.parameters, ({ name, value }) => {
+      const ptr = this.allocate(8)
+      this.setWord(ptr, this.writeString(name))
+      this.setWord(ptr + 4, this.writeValue(value))
+      return ptr
+    })
+
+    const ptr = this.allocate(28)
+    this.setWord(ptr, this.writeUint8Array(value.address))
+    this.setWord(ptr + 4, this.writeBigInt(value.logIndex))
+    this.setWord(ptr + 8, this.writeBigInt(value.transactionLogIndex))
+    this.setWord(ptr + 12, this.writeString(value.logType))
+    this.setWord(ptr + 16, blockPtr)
+    this.setWord(ptr + 20, txPtr)
+    this.setWord(ptr + 24, paramsPtr)
+
+    return ptr
+  }
+
+  public writeString(value: string | null): Pointer {
+    if (value === null) {
+      return 0
+    }
+
+    const ptr = this.allocate(4 + value.length * 2)
+    this.setWord(ptr, value.length)
+
+    const start = ptr + 4
+    for (let i = 0; i < value.length; i++) {
+      this.view.setUint16(start + i * 2, value.codePointAt(i) || 0, LE)
+    }
+
+    return ptr
+  }
+
+  public writeUint8Array(value: Uint8Array | null): Pointer {
+    if (value === null) {
+      return 0
+    }
+
+    const bufferPtr = this.writeArrayBuffer(value.buffer)
 
     const ptr = this.allocate(12)
-    this.view.setUint32(ptr, bufferPtr, LE)
-    this.view.setUint32(ptr + 4, bytes.byteOffset, LE)
-    this.view.setUint32(ptr + 8, bytes.length, LE)
+    this.setWord(ptr, bufferPtr)
+    this.setWord(ptr + 4, value.byteOffset)
+    this.setWord(ptr + 8, value.length)
+
+    return ptr
+  }
+
+  public writeValue(value: Value): Pointer {
+    let payload
+    switch (value.kind) {
+      case ValueKind.Address:
+      case ValueKind.FixedBytes:
+      case ValueKind.Bytes:
+        payload = this.writeUint8Array(value.data)
+        break
+      case ValueKind.Int:
+      case ValueKind.Uint:
+        payload = this.writeBigInt(value.data)
+        break
+      case ValueKind.Bool:
+        payload = ~~value.data
+        break
+      case ValueKind.String:
+        payload = this.writeString(value.data)
+        break
+      case ValueKind.FixedArray:
+      case ValueKind.Array:
+      case ValueKind.Tuple:
+        payload = this.writeArray(value.data, this.writeValue)
+        break
+      default:
+        throw new Error(`invalid ethereum value ${value}`)
+    }
+
+    const ptr = this.allocate(16)
+    this.setWord(ptr, value.kind)
+    this.view.setBigInt64(ptr + 8, BigInt(payload), LE)
 
     return ptr
   }

--- a/tests/runtime/ethereum.ts
+++ b/tests/runtime/ethereum.ts
@@ -1,0 +1,100 @@
+export type Hash = Uint8Array
+export type Address = Uint8Array
+
+export interface Block {
+  hash: Hash
+  parentHash: Hash
+  unclesHash: Hash
+  author: Address
+  stateRoot: Hash
+  transactionsRoot: Hash
+  receiptsRoot: Hash
+  number: bigint
+  gasUsed: bigint
+  gasLimit: bigint
+  timestamp: bigint
+  difficulty: bigint
+  totalDifficulty: bigint
+  size: bigint | null
+}
+
+export interface Transaction {
+  hash: Hash
+  index: bigint
+  from: Address
+  to: Address | null
+  value: bigint
+  gasUsed: bigint
+  gasPrice: bigint
+  input: Uint8Array
+}
+
+export enum ValueKind {
+  Address,
+  FixedBytes,
+  Bytes,
+  Int,
+  Uint,
+  Bool,
+  String,
+  FixedArray,
+  Array,
+  Tuple,
+}
+
+export type Value =
+  | {
+      kind: ValueKind.Address
+      data: Address
+    }
+  | {
+      kind: ValueKind.FixedBytes
+      data: Uint8Array
+    }
+  | {
+      kind: ValueKind.Bytes
+      data: Uint8Array
+    }
+  | {
+      kind: ValueKind.Int
+      data: bigint
+    }
+  | {
+      kind: ValueKind.Uint
+      data: bigint
+    }
+  | {
+      kind: ValueKind.Bool
+      data: boolean
+    }
+  | {
+      kind: ValueKind.String
+      data: string
+    }
+  | {
+      kind: ValueKind.FixedArray
+      data: Value[]
+    }
+  | {
+      kind: ValueKind.Array
+      data: Value[]
+    }
+  | {
+      kind: ValueKind.Tuple
+      data: Value[]
+    }
+
+export interface EventParam {
+  name: string
+  value: Value
+}
+
+export interface Event {
+  address: Address
+  logIndex: bigint
+  transactionLogIndex: bigint
+  logType: string | null
+  block: Block
+  transaction: Transaction
+  parameters: EventParam[]
+}

--- a/tests/runtime/events.ts
+++ b/tests/runtime/events.ts
@@ -1,0 +1,61 @@
+import { Event, EventParam } from './ethereum'
+import { hash, addr } from './hex'
+
+export const DEFAULT_CONTRACT_ADDRESS = addr('0x0001020304050607080910111213141516171819')
+
+export interface Deposit {
+  user: string
+  token: string
+  amount: bigint
+  batchId: number
+}
+
+export type Metadata = Partial<{
+  logIndex: number
+  blockNumber: number
+  blockTimestamp: number
+  transactionHash: string
+  transactionIndex: number
+  from: string
+}>
+
+export function newEvent(meta: Metadata, parameters: EventParam[]): Event {
+  const defaultAddr = new Uint8Array(20).fill(0xff)
+  const defaultHash = new Uint8Array(32).fill(0xff)
+
+  const num2hash = (value: number) => hash(`0x${value.toString().padStart(64, '0')}`)
+
+  return {
+    address: DEFAULT_CONTRACT_ADDRESS,
+    logIndex: BigInt(meta.logIndex || 0),
+    transactionLogIndex: BigInt(meta.logIndex || 0),
+    logType: null,
+    block: {
+      hash: num2hash(meta.blockNumber || 0),
+      parentHash: num2hash((meta.blockNumber || 1) - 1),
+      unclesHash: defaultHash,
+      author: defaultAddr,
+      stateRoot: defaultHash,
+      transactionsRoot: defaultHash,
+      receiptsRoot: defaultHash,
+      number: BigInt(meta.blockNumber || 0),
+      gasUsed: 4200000n,
+      gasLimit: 13370000n,
+      timestamp: BigInt(meta.blockTimestamp || 0),
+      difficulty: 42n,
+      totalDifficulty: 1337n,
+      size: null,
+    },
+    transaction: {
+      hash: meta.transactionHash ? hash(meta.transactionHash) : num2hash(meta.transactionIndex || 0),
+      index: BigInt(meta.transactionIndex || 0),
+      from: meta.from ? addr(meta.from) : defaultAddr,
+      to: DEFAULT_CONTRACT_ADDRESS,
+      value: 0n,
+      gasUsed: 1000000n,
+      gasPrice: 100n * 10n ** 9n,
+      input: new Uint8Array(),
+    },
+    parameters,
+  }
+}

--- a/tests/runtime/hex.ts
+++ b/tests/runtime/hex.ts
@@ -1,0 +1,32 @@
+import { Address, Hash } from './ethereum'
+
+export function addr(addr: string): Address {
+  return fixedLengthHex(addr, 20)
+}
+
+export function hash(hash: string): Hash {
+  return fixedLengthHex(hash, 32)
+}
+
+function fixedLengthHex(hex: string, len: number): Uint8Array {
+  const hexLen = len * 2 + 2
+  if (hex.length !== hexLen || !hex.match(/^0x[0-9A-Fa-f]*$/)) {
+    throw new Error(`invalid ${len}-byte hex string '${hex}'`)
+  }
+
+  const bytes = new Uint8Array(len)
+  for (let i = 0; i < len; i++) {
+    bytes[i] = parseInt(hex.substr(2 + i * 2, 2), 16)
+  }
+
+  return bytes
+}
+
+export function toHex(bytes: Uint8Array): string {
+  let str = '0x'
+  for (let i = 0; i < bytes.length; i++) {
+    str += bytes[i].toString(16).padStart(2, '0')
+  }
+
+  return str
+}

--- a/tests/runtime/int.ts
+++ b/tests/runtime/int.ts
@@ -14,7 +14,7 @@ export function toBytesLE(value: bigint): Uint8Array {
 
   // NOTE: For two's compliment, an extra byte is required if the MSb of the
   // MSB of the magnitude of value is 1.
-  const msb = parseInt(hex.substr(0, 1))
+  const msb = parseInt(hex.substr(0, 1), 16)
   const signSpace = msb & 0x8 ? 1 : 0
 
   const len = hex.length / 2


### PR DESCRIPTION
:warning: This PR requires rebasing :warning: 

This (unfortunately large) PR implements marshalling of Ethereum events from the JavaScript test harness to the Wasm mappings. This PR is long as the Graph Ethereum events contain a lot of data and marshalling these values is quite verbose.

### Test Plan

We can see a log message with the marshalled data (the [onDeposit] log message comes from Wasm :tada:):
```
$ DEBUG=runtime:* yarn test
yarn run v1.21.1
$ tsc && mocha -r ts-node/register tests/**/*.test.ts


  onDeposit
2020-09-17T20:51:30.444Z runtime:info [onDeposit] New Deposit: 0x4242424242424242424242424242424242424242424242424242424242424242
    ✓ creates a user if it does not exist (390ms)

  onAddToken
    ✓ adds a new token


  2 passing (397ms)

Done in 4.78s.
``` 