### PR TITLE
Add ability to set mock entities for testing handlers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,4 +16,11 @@ module.exports = {
     'prettier/@typescript-eslint',
   ],
   ignorePatterns: ['abis/', 'build/', 'generated/', 'node_modules/', '!.prettierrc.js'],
+  rules: {
+    // NOTE: We require TypeScript to target ES2020 for extended BigInt support
+    // that is available in NodeJS 12. However, this causes `tsc` to not emit
+    // extra code for optional chaining (`foo?.bar`) as that is part of ES2020.
+    // Allow use of `!` non-null assertions to work around this.
+    '@typescript-eslint/no-non-null-assertion': 'off',
+  },
 }

--- a/tests/deposits.test.ts
+++ b/tests/deposits.test.ts
@@ -28,4 +28,36 @@ describe('onDeposit', function () {
       fromBatchId: timestamp / 300n,
     })
   })
+
+  it('reuses existing user', async () => {
+    const mappings = await Mappings.load()
+
+    const userId = '0x0123456789012345678901234567890123456789'
+    const userTx = `0x${'01'.repeat(32)}`
+
+    // NOTE: Manually add an existing user entry that should be reused.
+    mappings.setEntity('User', userId, {
+      id: userId,
+      txHash: userTx,
+      createEpoch: 1337n,
+      fromBatchId: 4n,
+    })
+
+    mappings.onDeposit(
+      {
+        user: userId,
+        token: '0x0000000000000000000000000000000000000001',
+        amount: 10n ** 18n,
+        batchId: 42,
+      },
+      {
+        // NOTE: Different Tx hash and batch than the manually created user.
+        transactionHash: `0x${'02'.repeat(32)}`,
+      },
+    )
+
+    const user = mappings.getEntity('User', userId)
+    expect(user).to.not.be.null
+    expect(user!.txHash).to.equal(userTx)
+  })
 })

--- a/tests/wasm/events.ts
+++ b/tests/wasm/events.ts
@@ -28,7 +28,8 @@ export function deposit(deposit: Deposit, meta?: Metadata): Event {
       { name: 'batchId', value: { kind: ValueKind.Uint, data: BigInt(deposit.batchId) } },
     ],
     {
-      ...{ from: deposit.user },
+      blockTimestamp: BigInt(deposit.batchId) * 300n,
+      from: deposit.user,
       ...meta,
     },
   )

--- a/tests/wasm/index.ts
+++ b/tests/wasm/index.ts
@@ -36,4 +36,9 @@ export class Mappings {
 
     return Entities.toData(name, entity)
   }
+
+  public setEntity<T extends Entities.Names>(name: T, id: string, data: Entities.Data<T>): void {
+    const entity = Entities.fromData(name, data)
+    this.runtime.setEntity(name, id, entity)
+  }
 }

--- a/tests/wasm/runtime/convert.ts
+++ b/tests/wasm/runtime/convert.ts
@@ -1,22 +1,15 @@
 import { Address, Hash } from './ethereum'
 
-export function addrToBytes(addr: string): Address {
-  return fixedLengthHex(addr, 20)
-}
-
-export function hashToBytes(hash: string): Hash {
-  return fixedLengthHex(hash, 32)
-}
-
-function fixedLengthHex(hex: string, len: number): Uint8Array {
-  const hexLen = len * 2 + 2
-  if (hex.length !== hexLen || !hex.match(/^0x[0-9A-Fa-f]*$/)) {
-    throw new Error(`invalid ${len}-byte hex string '${hex}'`)
+export function fromHex(hex: string): Uint8Array {
+  if (!hex.match(/^0x([0-9A-Fa-f]{2})*$/)) {
+    throw new Error(`invalid hex string '${hex}'`)
   }
 
+  const hexData = hex.substr(2)
+  const len = hexData.length / 2
   const bytes = new Uint8Array(len)
   for (let i = 0; i < len; i++) {
-    bytes[i] = parseInt(hex.substr(2 + i * 2, 2), 16)
+    bytes[i] = parseInt(hexData.substr(2 * i, 2), 16)
   }
 
   return bytes
@@ -29,4 +22,21 @@ export function toHex(bytes: Uint8Array): string {
   }
 
   return str
+}
+
+export function addrToBytes(addr: string): Address {
+  return fixedLengthHex(addr, 20)
+}
+
+export function hashToBytes(hash: string): Hash {
+  return fixedLengthHex(hash, 32)
+}
+
+function fixedLengthHex(hex: string, len: number): Uint8Array {
+  const hexLen = len * 2 + 2
+  if (hex.length !== hexLen) {
+    throw new Error(`invalid ${len}-byte hex string '${hex}'`)
+  }
+
+  return fromHex(hex)
 }


### PR DESCRIPTION
This PR adds the ability to set mock entities in the mock Graph runtime for handler tests.

### Test Plan

Add a new test that makes use of this feature.