### PR TITLE
Add integration test harness with sample test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,4 @@ node_js:
   - lts/*
 cache: yarn
 script:
-  - yarn lint
-  - yarn build
-  - yarn test
+  - yarn ci && ./e2e/ci.sh

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPO="$(realpath "$(dirname $0)/..")"
+COMPOSE_FILE="e2e/docker-compose.yaml"
+INDEXING_CHECK_RETRIES=6
+INDEXING_CHECK_INTERVAL=5s
+
+docker_compose() {
+  docker-compose -f "$COMPOSE_FILE" "$@"
+}
+
+on_exit() {
+  echo "## Shutting down local Graph node"
+  docker_compose logs graph-node
+  docker_compose rm --stop -f
+}
+trap on_exit EXIT
+
+echo "## Running E2E tests from '$REPO'"
+cd $REPO
+
+echo "## Starting local Graph node"
+docker_compose up -d graph-node
+
+echo "## Deploying Gnosis Protocol to testnet"
+docker_compose up dex-contracts
+
+echo "## Deploying subgraph to local Graph node"
+yarn create-ganache
+yarn deploy
+
+echo "## Waiting for subgraph to index"
+for i in $(seq 1 $INDEXING_CHECK_RETRIES); do
+  synced=$(
+    curl -s \
+      -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{ "query": "{ i: indexingStatusesForSubgraphName(subgraphName: \"gnosis/protocol\") { synced } }" }' \
+      http://127.0.0.1:8030/graphql \
+    | jq '.data.i[0].synced'
+  )
+  if [[ "$synced" == "true" ]]; then
+    break
+  fi
+  sleep $INDEXING_CHECK_INTERVAL
+done
+if [[ "$synced" == "false" ]]; then
+  echo "ERROR: Subgraph not indexed in time"
+  exit 1
+fi
+
+echo "## Running E2E test suite"
+yarn test:e2e

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: '3'
+services:
+  graph-node:
+    image: graphprotocol/graph-node
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+      - '8020:8020'
+      - '8030:8030'
+      - '8040:8040'
+    depends_on:
+      - ganache
+      - ipfs
+      - postgres
+    environment:
+      postgres_host: postgres:5432
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: ipfs:5001
+      ethereum: mainnet:http://ganache:8545
+      RUST_LOG: info
+
+  dex-contracts:
+    build:
+      context: ./docker/dex-contracts
+    image: dex-contracts:v0.4.3
+    depends_on:
+      - ganache
+    environment:
+      GANACHE_HOST: ganache
+  ganache:
+    image: trufflesuite/ganache-cli:v6.10.2
+    ports:
+      - '8545:8545'
+    command: ["-d", "-l", "0x800000"]
+  ipfs:
+    image: ipfs/go-ipfs:v0.4.23
+    ports:
+      - '5001:5001'
+  postgres:
+    image: postgres:12
+    ports:
+      - '5432:5432'
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -20,7 +20,6 @@ services:
       ipfs: ipfs:5001
       ethereum: mainnet:http://ganache:8545
       RUST_LOG: info
-
   dex-contracts:
     build:
       context: ./docker/dex-contracts

--- a/e2e/docker/dex-contracts/Dockerfile
+++ b/e2e/docker/dex-contracts/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:lts
+
+WORKDIR /app/dex-contracts
+
+RUN git clone --depth 1 --branch v0.4.3 https://github.com/gnosis/dex-contracts . &&\
+    yarn && yarn prepack
+ADD entrypoint.sh .
+
+CMD ["./entrypoint.sh"]

--- a/e2e/docker/dex-contracts/entrypoint.sh
+++ b/e2e/docker/dex-contracts/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+npx truffle migrate
+yarn truffle-exec scripts/ganache/setup_thegraph_data.ts

--- a/e2e/tests/graphql.ts
+++ b/e2e/tests/graphql.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch'
+
+const GRAPH_HOST = process.env.GRAPH_HOST || '127.0.0.1:8000'
+const GRAPH_URL = process.env.GRAPH_URL || `http://${GRAPH_HOST}/subgraphs/name/gnosis/protocol`
+
+export async function query(q: string): Promise<unknown> {
+  const response = await fetch(GRAPH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: q }),
+  })
+
+  const json = await response.json()
+  if (json.error !== undefined || json.data === undefined) {
+    throw new Error((json.error || {}).message || `unknown GraphQL error: ${JSON.stringify(json)}`)
+  }
+
+  return json.data
+}

--- a/e2e/tests/subgraph.test.ts
+++ b/e2e/tests/subgraph.test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+import { query } from './graphql'
+
+describe('Subgraph', function () {
+  it('should list tokens', async () => {
+    const tokens = await query(`{
+      tokens {
+        id
+      }
+    }`)
+    expect(tokens).to.deep.equal({
+      tokens: [{ id: '0' }, { id: '1' }],
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "deploy-xdai": "npm run prepare:xdai && graph deploy gnosis/protocol-xdai --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "lint": "eslint --max-warnings 0 .",
     "lint:fix": "eslint --fix .",
-    "test": "tsc && mocha -r ts-node/register tests/**/*.test.ts"
+    "ts:check": "tsc",
+    "test": "mocha -r ts-node/register tests/**/*.test.ts",
+    "test:e2e": "mocha -r ts-node/register e2e/tests/**/*.test.ts",
+    "ci": "yarn lint && yarn build && yarn ts:check && yarn test"
   },
   "dependencies": {
     "@gnosis.pm/dex-contracts": "=0.4.3",
@@ -36,6 +39,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^12.12.59",
+    "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "chai": "^4.2.0",
@@ -46,6 +50,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^8.1.3",
     "mustache": "^4.0.1",
+    "node-fetch": "^2.6.1",
     "prettier": "^2.1.1",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.3.tgz#51b21b6acb6d1b923bbdc7725c38f9f455166402"
   integrity sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
@@ -865,7 +873,7 @@ colors@^1.1.2, colors@^1.3.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1554,6 +1562,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -2878,7 +2895,7 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
-node-fetch@^2.3.0:
+node-fetch@^2.3.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
This PR adds a `docker-compose` based test harness for performing `dex-subgraph` integration tests.

### Test Plan

CI with new integration test :tada: 