### PR TITLE
Wasm `start` function rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mustache": "^4.0.1",
     "prettier": "^2.1.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "wabt": "^1.0.19"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3987,6 +3987,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+wabt@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/wabt/-/wabt-1.0.19.tgz#3efa9ab225498975ececea7d2a827da0ef35118f"
+  integrity sha512-z/7XRZB8tPRW0XdE8HYbA95w2kjus5AwOHnJ5NT9PqzaNZ7z/zHnUdpNdB78TFMgWt+D/u01lg1jG6nWiFmyEw==
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
This PR rewrites the Wasm to remove the AssemblyScript `start` function, and instead expose it as an exprot. This is done because the compiled AssemblyScript WebAssembly module calls exports in its `start` initialization method that **require** exports to work (for example `index/bigInt.pow` which requires the exported `memory`). This, unfortunately is not supported with the JavaScript WebAssembly API. To work around this, we disable the `start` function and add it as an export to be called manually **after** the module has been compiled.

### Test Plan

This PR can't be tested as is, as the Wasm start function requires exports that have currently not been implemented. It will be tested in a future PR.
