### PR TITLE
Add big integer implementation

### DIFF
--- a/tests/runtime/abi.ts
+++ b/tests/runtime/abi.ts
@@ -1,21 +1,68 @@
+import { fromBytesLE, toBytesLE } from './int'
+
 const LE = true
 const ENCODING = 'utf-16le'
 
 export type Pointer = number
 
 export class Abi {
-  private text = {
+  private readonly text = {
     decoder: new TextDecoder(ENCODING),
   }
 
-  constructor(private memory: WebAssembly.Memory) {}
+  constructor(private memory: WebAssembly.Memory, private allocator: (size: number) => Pointer) {}
+
+  private get buffer() {
+    return this.memory.buffer
+  }
 
   private get heap() {
-    return new Uint8Array(this.memory.buffer)
+    return new Uint8Array(this.buffer)
   }
 
   private get view() {
-    return new DataView(this.memory.buffer)
+    return new DataView(this.buffer)
+  }
+
+  private allocate(size: number): Pointer {
+    const MAX_SIZE = 0x80000000
+    if (size < 1 || size > MAX_SIZE) {
+      throw new Error(`allocation size ${size} is invalid`)
+    }
+
+    // NOTE: AssemblyScript arena allocator requires allocs to be powers of 2.
+    // This is done by shifting `u32::MAX` the number of leading zeros in `size`
+    // and then adding `1` to make the next power of two.
+    const nextPowerOfTwo = (0xffffffff >> Math.clz32(size - 1)) + 1
+
+    return this.allocator(nextPowerOfTwo)
+  }
+
+  public readArrayBuffer(ptr: Pointer): ArrayBuffer | null {
+    if (ptr === 0) {
+      return null
+    }
+
+    const len = this.view.getUint32(ptr, LE)
+    const start = ptr + 8 // 4 bytes padding
+    return this.buffer.slice(start, start + len)
+  }
+
+  public readBigInt(ptr: Pointer): bigint | null {
+    if (ptr === 0) {
+      return null
+    }
+
+    const buffer = this.readArrayBuffer(this.view.getUint32(ptr, LE))
+    if (buffer === null) {
+      throw new Error('BitInt with null buffer')
+    }
+
+    const offset = this.view.getUint32(ptr + 4, LE)
+    const len = this.view.getUint32(ptr + 8, LE)
+
+    const bytes = new Uint8Array(buffer, offset, len)
+    return fromBytesLE(bytes)
   }
 
   public readString(ptr: Pointer): string | null {
@@ -27,5 +74,26 @@ export class Abi {
     const start = ptr + 4
     const bytes = this.heap.subarray(start, start + len * 2)
     return this.text.decoder.decode(bytes)
+  }
+
+  public writeArrayBuffer(value: ArrayBuffer): Pointer {
+    const ptr = this.allocate(8 + value.byteLength)
+
+    this.view.setUint32(ptr, value.byteLength, LE)
+    this.heap.set(new Uint8Array(value), ptr + 8)
+
+    return ptr
+  }
+
+  public writeBigInt(value: bigint): Pointer {
+    const bytes = toBytesLE(value)
+    const bufferPtr = this.writeArrayBuffer(bytes)
+
+    const ptr = this.allocate(12)
+    this.view.setUint32(ptr, bufferPtr, LE)
+    this.view.setUint32(ptr + 4, 0, LE)
+    this.view.setUint32(ptr + 8, bytes.length, LE)
+
+    return ptr
   }
 }

--- a/tests/runtime/abi.ts
+++ b/tests/runtime/abi.ts
@@ -91,7 +91,7 @@ export class Abi {
 
     const ptr = this.allocate(12)
     this.view.setUint32(ptr, bufferPtr, LE)
-    this.view.setUint32(ptr + 4, 0, LE)
+    this.view.setUint32(ptr + 4, bytes.byteOffset, LE)
     this.view.setUint32(ptr + 8, bytes.length, LE)
 
     return ptr

--- a/tests/runtime/int.ts
+++ b/tests/runtime/int.ts
@@ -1,0 +1,56 @@
+export function toBytesLE(value: bigint): Uint8Array {
+  if (value === 0n) {
+    return new Uint8Array(0)
+  }
+
+  const negative = value < 0n
+  const valueAbs = negative ? -value : value
+
+  let hex = valueAbs.toString(16)
+  if (hex.length & 1) {
+    // NOTE: Ensure an even number of bytes.
+    hex = `0${hex}`
+  }
+
+  // NOTE: For two's compliment, an extra byte is required if the MSb of the
+  // MSB of the magnitude of value is 1.
+  const msb = parseInt(hex.substr(0, 1))
+  const signSpace = msb & 0x8 ? 1 : 0
+
+  const len = hex.length / 2
+  const bytes = new Uint8Array(len + signSpace)
+  for (let i = 0; i < len; i++) {
+    bytes[i] = parseInt(hex.substr((len - i - 1) * 2, 2), 16)
+  }
+
+  if (negative) {
+    twosCompliment(bytes)
+  }
+
+  return bytes
+}
+
+export function fromBytesLE(bytes: Uint8Array): bigint {
+  const negative = !!(bytes[bytes.length - 1] & 0x80)
+  if (negative) {
+    twosCompliment(bytes)
+  }
+
+  let result = 0n
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    result = (result << 8n) | BigInt(bytes[i])
+  }
+
+  return negative ? -result : result
+}
+
+function twosCompliment(bytes: Uint8Array) {
+  let carry = true
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = ~bytes[i]
+    if (carry) {
+      bytes[i] = (bytes[i] + 1) & 0xff
+      carry = bytes[i] === 0
+    }
+  }
+}

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -3,6 +3,7 @@ import { Mappings } from './runtime'
 
 describe('onAddToken', function () {
   it('adds a new token', async () => {
-    await Mappings.load().catch((err) => expect(err.message).to.equal('not implemented'))
+    const mappings = await Mappings.load()
+    expect(() => mappings.onAddToken()).to.throw()
   })
 })


### PR DESCRIPTION
This PR adds Wasm import `BigInt` implementation.

### Test Plan


Unit test with `Mappings.load()` succeeding while calling Wasm `start` function :tada: 