### PR TITLE
Use token listing event instead of indexing calls.

### DIFF
--- a/config/ganache.json
+++ b/config/ganache.json
@@ -1,5 +1,4 @@
 {
   "network": "mainnet",
-  "address": "0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7",
-  "indexCalls": false
+  "address": "0x9561C133DD8580860B6b7E504bC5Aa500f0f06a7"
 }

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,6 +1,5 @@
 {
   "network": "mainnet",
   "address": "0x6F400810b62df8E13fded51bE75fF5393eaa841F",
-  "startBlock": 9340147,
-  "indexCalls": true
+  "startBlock": 9340147
 }

--- a/config/rinkeby.json
+++ b/config/rinkeby.json
@@ -1,6 +1,5 @@
 {
   "network": "rinkeby",
   "address": "0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2",
-  "startBlock": 5844678,
-  "indexCalls": false
+  "startBlock": 5844678
 }

--- a/config/xdai.json
+++ b/config/xdai.json
@@ -1,6 +1,5 @@
 {
   "network": "xdai",
   "address": "0x25B06305CC4ec6AfCF3E7c0b673da1EF8ae26313",
-  "startBlock": 11948310,
-  "indexCalls": false
+  "startBlock": 11948310
 }

--- a/src/mappings/index.ts
+++ b/src/mappings/index.ts
@@ -1,4 +1,4 @@
-export { onAddToken } from './tokens'
+export { onTokenListing } from './tokens'
 export { onOrderPlacement, onOrderCancellation, onOrderDeletion } from './orders'
 export { onTrade, onTradeReversion } from './trades'
 export { onDeposit } from './deposits'

--- a/src/mappings/orders.ts
+++ b/src/mappings/orders.ts
@@ -6,7 +6,7 @@ import {
 } from '../../generated/BatchExchange/BatchExchange'
 import { Order, Token, Trade, User } from '../../generated/schema'
 import { toOrderId, batchIdToEpoch, getBatchId } from '../utils'
-import { createTokenIfNotCreated } from './tokens'
+import { getTokenById } from './tokens'
 import { createUserIfNotCreated } from './users'
 
 export function onOrderPlacement(event: OrderPlacementEvent): void {
@@ -15,9 +15,10 @@ export function onOrderPlacement(event: OrderPlacementEvent): void {
   // Crete user if doesn't exist
   let owner = createUserIfNotCreated(params.owner, event)
 
-  // Crete tokens if they don't exist
-  let sellToken = createTokenIfNotCreated(params.sellToken, event)
-  let buyToken = createTokenIfNotCreated(params.buyToken, event)
+  // Get existing token entities - the `BatchExchange` contract requires token
+  // IDs to be valid to place orders.
+  let sellToken = getTokenById(params.sellToken)
+  let buyToken = getTokenById(params.buyToken)
 
   // Create order
   _createOrder(event, owner, sellToken, buyToken)

--- a/subgraph.yaml.mustache
+++ b/subgraph.yaml.mustache
@@ -38,13 +38,11 @@ dataSources:
           file: ./abis/BatchExchange.json
         - name: Erc20
           file: ./abis/Erc20.json
-{{#indexCalls}}
-      callHandlers:
-        # Tokens
-        - function: addToken(address)
-          handler: onAddToken
-{{/indexCalls}}
       eventHandlers:
+        # Tokens
+        - event: TokenListing(address,uint16)
+          handler: onTokenListing
+
         # Deposits
         - event: Deposit(indexed address,indexed address,uint256,uint32)
           handler: onDeposit


### PR DESCRIPTION
Call indexing is only available on mainnet and not rinkeby or xdai networks. This PR modifies the token event listing handler to use the `TokenListing` event, which should be enough anyway!

### Test Plan

Integration test currently tests token listings - CI will make sure that it still works! Unfortunately, we can't add unit tests for this handler as it requires mocking `eth_call`s which is currently not implemented.

Additionally, it has been deployed on the xDAI subgraph. Go to <https://thegraph.com/explorer/subgraph/gnosis/protocol-xdai> and try the following query:

```graphql
{
  tokens {
    id
    symbol
    name
    decimals
  }
}
```

Previously, only tokens with orders would show up.