### PR TITLE
Add mocked ethereum call implementation

### DIFF
--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai'
+import { Mappings } from './wasm'
+import { ValueKind } from './wasm/runtime/ethereum'
+
+describe('onTokenListing', function () {
+  it('creates a token', async () => {
+    const mappings = await Mappings.load()
+    mappings.setCallHandler((call) => {
+      const callName = `${call.contractName}.${call.functionName}`
+      switch (callName) {
+        case `Erc20.symbol`:
+          return [{ kind: ValueKind.String, data: 'TEST' }]
+        case `Erc20.name`:
+          return [{ kind: ValueKind.String, data: 'Test Token' }]
+        case `Erc20.decimals`:
+          return [{ kind: ValueKind.Uint, data: 18n }]
+        default:
+          throw new Error(`unexpected contract call ${callName}`)
+      }
+    })
+
+    mappings.onTokenListing(
+      {
+        id: 42,
+        token: '0x1337133713371337133713371337133713371337',
+      },
+      {
+        block: {
+          timestamp: 42 * 300,
+        },
+        transaction: {
+          hash: `0x${'42'.repeat(32)}`,
+        },
+      },
+    )
+
+    expect(mappings.getEntity('Token', '42')).to.deep.equal({
+      id: '42',
+      address: '0x1337133713371337133713371337133713371337',
+      fromBatchId: 42n,
+      symbol: 'TEST',
+      decimals: 18n,
+      name: 'Test Token',
+      createEpoch: 42n * 300n,
+      txHash: `0x${'42'.repeat(32)}`,
+    })
+  })
+
+  it('accepts tokens without details', async () => {
+    const mappings = await Mappings.load()
+    mappings.setCallHandler(() => null)
+
+    mappings.onTokenListing({
+      id: 0,
+      token: `0x${'00'.repeat(20)}`,
+    })
+
+    const { symbol, name, decimals } = mappings.getEntity('Token', '0')!
+    expect({ symbol, name, decimals }).to.deep.equal({
+      symbol: null,
+      name: null,
+      decimals: null,
+    })
+  })
+})

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -10,6 +10,10 @@ const EventDefinitions = {
     amount: Ethereum.ValueKind.Uint,
     batchId: Ethereum.ValueKind.Uint,
   },
+  TokenListing: {
+    token: Ethereum.ValueKind.Address,
+    id: Ethereum.ValueKind.Uint,
+  },
 } as const
 
 export type EventNames = keyof typeof EventDefinitions
@@ -33,6 +37,16 @@ const EntityDefinitions = {
     tokenAddress: Store.ValueKind.Bytes,
     amount: Store.ValueKind.BigInt,
     batchId: Store.ValueKind.BigInt,
+    createEpoch: Store.ValueKind.BigInt,
+    txHash: Store.ValueKind.Bytes,
+  },
+  Token: {
+    id: Store.ValueKind.String,
+    address: Store.ValueKind.Bytes,
+    fromBatchId: Store.ValueKind.BigInt,
+    symbol: { optional: Store.ValueKind.String },
+    decimals: { optional: Store.ValueKind.BigInt },
+    name: { optional: Store.ValueKind.String },
     createEpoch: Store.ValueKind.BigInt,
     txHash: Store.ValueKind.Bytes,
   },

--- a/tests/wasm/runtime/chain.ts
+++ b/tests/wasm/runtime/chain.ts
@@ -1,0 +1,13 @@
+import { Call, Value } from './ethereum'
+
+export type CallHandler = (call: Call) => Value[] | null
+
+export interface IEthereum {
+  call: CallHandler
+}
+
+export const DEFAULT_ETHEREUM: IEthereum = {
+  call: ({ contractName, functionSignature }: Call) => {
+    throw new Error(`unexpected ethereum call ${contractName}.${functionSignature}`)
+  },
+}

--- a/tests/wasm/runtime/ethereum.ts
+++ b/tests/wasm/runtime/ethereum.ts
@@ -98,3 +98,11 @@ export interface Event {
   transaction: Transaction
   parameters: EventParam[]
 }
+
+export interface Call {
+  contractName: string
+  contractAddress: Address
+  functionName: string
+  functionSignature: string
+  functionParams: Value[]
+}

--- a/tests/wasm/runtime/host.ts
+++ b/tests/wasm/runtime/host.ts
@@ -1,9 +1,11 @@
 import { Logger } from './log'
 import { Store } from './store'
+import { DEFAULT_ETHEREUM } from './chain'
 
 export class Host {
   public readonly log = new Logger()
   public readonly store = new Store()
+  public eth = DEFAULT_ETHEREUM
 
   public abort(message: string, fileName: string | null, line: number, column: number): void {
     const f = fileName || '?'


### PR DESCRIPTION
This PR adds an implementation for the last used The Graph host import :tada:  - `eth_call`s. With it comes unit tests for the new token listing handler code.

### Test Plan

Added new unit tests to run on CI :robot: 