### PR TITLE
Implement trade reversions

### DIFF
--- a/src/mappings/orders.ts
+++ b/src/mappings/orders.ts
@@ -31,6 +31,13 @@ export function updateOrderOnNewTrade(orderId: string, trade: Trade): void {
   order.save()
 }
 
+export function updateOrderOnTradeReversion(orderId: string, trade: Trade): void {
+  let order = getOrderById(orderId)
+  order.soldVolume = order.soldVolume.minus(trade.sellVolume)
+  order.boughtVolume = order.boughtVolume.minus(trade.buyVolume)
+  order.save()
+}
+
 export function onOrderCancellation(event: OrderCancellationEvent): void {
   let params = event.params
 

--- a/tests/trades.test.ts
+++ b/tests/trades.test.ts
@@ -73,6 +73,93 @@ describe('onTradeReversion', function () {
     expect(trade!.revertEpoch).to.equal(timestamp)
   })
 
+  it('reverts correct trade when solution gets reverted twice', async () => {
+    const mappings = await Mappings.load()
+
+    const user = `0x${'1337'.repeat(10)}`
+    const orderId = 1337n
+    const orderUid = `${user}-${orderId}`
+    const trade0Id = `0x${'01'.repeat(32)}-1`
+    const trade1Id = `0x${'02'.repeat(32)}-2`
+    mappings.setEntity('Order', `${user}-${orderId}`, {
+      id: orderUid,
+      owner: user,
+      orderId,
+      fromBatchId: 0n,
+      fromEpoch: 0n,
+      untilBatchId: 42n,
+      untilEpoch: 42n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      priceNumerator: 200000n * 10n ** 18n,
+      priceDenominator: 1000n * 10n ** 18n,
+      maxSellAmount: 200000n * 10n ** 18n,
+      minReceiveAmount: 1000n * 10n ** 18n,
+      soldVolume: 100000n * 10n ** 18n,
+      boughtVolume: 500n * 10n ** 18n,
+      trades: [trade0Id, trade1Id],
+      createEpoch: 0n,
+      cancelEpoch: null,
+      deleteEpoch: null,
+      txHash: `0x${'00'.repeat(32)}`,
+      txLogIndex: 0n,
+    })
+    mappings.setEntity('Trade', trade0Id, {
+      id: trade0Id,
+      order: orderUid,
+      owner: user,
+      sellVolume: 140000n * 10n ** 18n,
+      buyVolume: 700n * 10n ** 18n,
+      tradeBatchId: 9n,
+      tradeEpoch: 10n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      createEpoch: 10n * 300n,
+      revertEpoch: 10n * 300n + 1n, // previously reverted trade
+      txHash: `0x${'01'.repeat(32)}`,
+      txLogIndex: 1n,
+    })
+    mappings.setEntity('Trade', trade1Id, {
+      id: trade1Id,
+      order: orderUid,
+      owner: user,
+      sellVolume: 100000n * 10n ** 18n,
+      buyVolume: 500n * 10n ** 18n,
+      tradeBatchId: 9n,
+      tradeEpoch: 10n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      createEpoch: 10n * 300n + 2n,
+      revertEpoch: null,
+      txHash: `0x${'02'.repeat(32)}`,
+      txLogIndex: 2n,
+    })
+
+    const timestamp = 10n * 300n + 3n
+    mappings.onTradeReversion(
+      {
+        owner: user,
+        orderId,
+        sellToken: 0,
+        buyToken: 1,
+        executedSellAmount: 100000n * 10n ** 18n,
+        executedBuyAmount: 500n * 10n ** 18n,
+      },
+      {
+        block: { timestamp },
+      },
+    )
+
+    const order = mappings.getEntity('Order', orderUid)
+    expect(order).to.exist
+    expect(order!.soldVolume).to.equal(0n)
+    expect(order!.boughtVolume).to.equal(0n)
+
+    const trade = mappings.getEntity('Trade', trade1Id)
+    expect(trade).to.exist
+    expect(trade!.revertEpoch).to.equal(timestamp)
+  })
+
   it('errors if order does not exit', async () => {
     const mappings = await Mappings.load()
     expect(() =>

--- a/tests/trades.test.ts
+++ b/tests/trades.test.ts
@@ -134,7 +134,7 @@ describe('onTradeReversion', function () {
     ).to.throw('aborted')
   })
 
-  it('errors if there are no active trades for an order', async () => {
+  it('errors if there is more than one active trade for an order', async () => {
     const mappings = await Mappings.load()
 
     const user = `0x${'01'.repeat(20)}`

--- a/tests/trades.test.ts
+++ b/tests/trades.test.ts
@@ -1,0 +1,214 @@
+import { expect } from 'chai'
+import { Mappings } from './wasm'
+
+describe('onTradeReversion', function () {
+  it('updates order total amounts and trade reversion epoch', async () => {
+    const mappings = await Mappings.load()
+
+    const user = `0x${'1337'.repeat(10)}`
+    const orderId = 1337n
+    const orderUid = `${user}-${orderId}`
+    const tradeId = `0x${'01'.repeat(32)}-1`
+    mappings.setEntity('Order', `${user}-${orderId}`, {
+      id: orderUid,
+      owner: user,
+      orderId,
+      fromBatchId: 0n,
+      fromEpoch: 0n,
+      untilBatchId: 42n,
+      untilEpoch: 42n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      priceNumerator: 200000n * 10n ** 18n,
+      priceDenominator: 1000n * 10n ** 18n,
+      maxSellAmount: 200000n * 10n ** 18n,
+      minReceiveAmount: 1000n * 10n ** 18n,
+      soldVolume: 100000n * 10n ** 18n,
+      boughtVolume: 500n * 10n ** 18n,
+      trades: [tradeId],
+      createEpoch: 0n,
+      cancelEpoch: null,
+      deleteEpoch: null,
+      txHash: `0x${'00'.repeat(32)}`,
+      txLogIndex: 0n,
+    })
+    mappings.setEntity('Trade', tradeId, {
+      id: tradeId,
+      order: orderUid,
+      owner: user,
+      sellVolume: 100000n * 10n ** 18n,
+      buyVolume: 500n * 10n ** 18n,
+      tradeBatchId: 9n,
+      tradeEpoch: 10n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      createEpoch: 10n * 300n,
+      revertEpoch: null,
+      txHash: `0x${'01'.repeat(32)}`,
+      txLogIndex: 1n,
+    })
+
+    const timestamp = 10n * 300n + 42n
+    mappings.onTradeReversion(
+      {
+        owner: user,
+        orderId,
+        sellToken: 0,
+        buyToken: 1,
+        executedSellAmount: 100000n * 10n ** 18n,
+        executedBuyAmount: 500n * 10n ** 18n,
+      },
+      {
+        block: { timestamp },
+      },
+    )
+
+    const order = mappings.getEntity('Order', orderUid)
+    expect(order).to.exist
+    expect(order!.soldVolume).to.equal(0n)
+    expect(order!.boughtVolume).to.equal(0n)
+
+    const trade = mappings.getEntity('Trade', tradeId)
+    expect(trade).to.exist
+    expect(trade!.revertEpoch).to.equal(timestamp)
+  })
+
+  it('errors if order does not exit', async () => {
+    const mappings = await Mappings.load()
+    expect(() =>
+      mappings.onTradeReversion({
+        owner: `0x${'00'.repeat(20)}`,
+        orderId: 0,
+        sellToken: 0,
+        buyToken: 1,
+        executedSellAmount: 100000n * 10n ** 18n,
+        executedBuyAmount: 500n * 10n ** 18n,
+      }),
+    ).to.throw('aborted')
+  })
+
+  it('errors if there are no active trades for an order', async () => {
+    const mappings = await Mappings.load()
+
+    const user = `0x${'01'.repeat(20)}`
+    const orderId = 1337n
+    const orderUid = `${user}-${orderId}`
+    mappings.setEntity('Order', orderUid, {
+      id: orderUid,
+      owner: user,
+      orderId,
+      fromBatchId: 0n,
+      fromEpoch: 0n,
+      untilBatchId: 42n,
+      untilEpoch: 42n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      priceNumerator: 200000n * 10n ** 18n,
+      priceDenominator: 1000n * 10n ** 18n,
+      maxSellAmount: 200000n * 10n ** 18n,
+      minReceiveAmount: 1000n * 10n ** 18n,
+      soldVolume: 100000n * 10n ** 18n,
+      boughtVolume: 500n * 10n ** 18n,
+      trades: [],
+      createEpoch: 0n,
+      cancelEpoch: null,
+      deleteEpoch: null,
+      txHash: `0x${'00'.repeat(32)}`,
+      txLogIndex: 0n,
+    })
+
+    expect(() =>
+      mappings.onTradeReversion(
+        {
+          owner: user,
+          orderId,
+          sellToken: 0,
+          buyToken: 1,
+          executedSellAmount: 100000n * 10n ** 18n,
+          executedBuyAmount: 500n * 10n ** 18n,
+        },
+        {
+          block: { timestamp: 10n * 300n },
+        },
+      ),
+    ).to.throw('aborted')
+  })
+
+  it('errors if there are no active trades for an order', async () => {
+    const mappings = await Mappings.load()
+
+    const user = `0x${'01'.repeat(20)}`
+    const orderId = 1337n
+    const orderUid = `${user}-${orderId}`
+    const solutionTx = `0x${'10'.repeat(32)}`
+    mappings.setEntity('Order', orderUid, {
+      id: orderUid,
+      owner: user,
+      orderId,
+      fromBatchId: 0n,
+      fromEpoch: 0n,
+      untilBatchId: 42n,
+      untilEpoch: 42n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      priceNumerator: 200000n * 10n ** 18n,
+      priceDenominator: 1000n * 10n ** 18n,
+      maxSellAmount: 200000n * 10n ** 18n,
+      minReceiveAmount: 1000n * 10n ** 18n,
+      soldVolume: 100000n * 10n ** 18n,
+      boughtVolume: 500n * 10n ** 18n,
+      trades: [],
+      createEpoch: 0n,
+      cancelEpoch: null,
+      deleteEpoch: null,
+      txHash: `0x${'00'.repeat(32)}`,
+      txLogIndex: 0n,
+    })
+    mappings.setEntity('Trade', `${user}-1`, {
+      id: `${user}-1`,
+      order: orderUid,
+      owner: user,
+      sellVolume: 100000n * 10n ** 18n,
+      buyVolume: 500n * 10n ** 18n,
+      tradeBatchId: 9n,
+      tradeEpoch: 10n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      createEpoch: 10n * 300n,
+      revertEpoch: null,
+      txHash: solutionTx,
+      txLogIndex: 1n,
+    })
+    mappings.setEntity('Trade', `${user}-2`, {
+      id: `${user}-2`,
+      order: orderUid,
+      owner: user,
+      sellVolume: 100000n * 10n ** 18n,
+      buyVolume: 500n * 10n ** 18n,
+      tradeBatchId: 9n,
+      tradeEpoch: 10n * 300n,
+      buyToken: '0',
+      sellToken: '1',
+      createEpoch: 10n * 300n,
+      revertEpoch: null,
+      txHash: solutionTx,
+      txLogIndex: 2n,
+    })
+
+    expect(() =>
+      mappings.onTradeReversion(
+        {
+          owner: user,
+          orderId,
+          sellToken: 0,
+          buyToken: 1,
+          executedSellAmount: 100000n * 10n ** 18n,
+          executedBuyAmount: 500n * 10n ** 18n,
+        },
+        {
+          block: { timestamp: 10n * 300n },
+        },
+      ),
+    ).to.throw('aborted')
+  })
+})

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -14,6 +14,14 @@ const EventDefinitions = {
     token: Ethereum.ValueKind.Address,
     id: Ethereum.ValueKind.Uint,
   },
+  TradeReversion: {
+    owner: Ethereum.ValueKind.Address,
+    orderId: Ethereum.ValueKind.Uint,
+    sellToken: Ethereum.ValueKind.Uint,
+    buyToken: Ethereum.ValueKind.Uint,
+    executedSellAmount: Ethereum.ValueKind.Uint,
+    executedBuyAmount: Ethereum.ValueKind.Uint,
+  },
 } as const
 
 export type EventNames = keyof typeof EventDefinitions
@@ -25,12 +33,6 @@ export function toEvent<K extends EventNames>(name: K, data: EventData<K>, meta?
 }
 
 const EntityDefinitions = {
-  User: {
-    id: Store.ValueKind.String,
-    fromBatchId: Store.ValueKind.BigInt,
-    createEpoch: Store.ValueKind.BigInt,
-    txHash: Store.ValueKind.Bytes,
-  },
   Deposit: {
     id: Store.ValueKind.String,
     user: Store.ValueKind.String,
@@ -40,6 +42,30 @@ const EntityDefinitions = {
     createEpoch: Store.ValueKind.BigInt,
     txHash: Store.ValueKind.Bytes,
   },
+  Order: {
+    id: Store.ValueKind.String,
+    owner: Store.ValueKind.String,
+    orderId: Store.ValueKind.BigInt,
+    fromBatchId: Store.ValueKind.BigInt,
+    fromEpoch: Store.ValueKind.BigInt,
+    untilBatchId: Store.ValueKind.BigInt,
+    untilEpoch: Store.ValueKind.BigInt,
+    buyToken: Store.ValueKind.String,
+    sellToken: Store.ValueKind.String,
+    priceNumerator: Store.ValueKind.BigInt,
+    priceDenominator: Store.ValueKind.BigInt,
+    maxSellAmount: Store.ValueKind.BigInt,
+    minReceiveAmount: Store.ValueKind.BigInt,
+    soldVolume: Store.ValueKind.BigInt,
+    boughtVolume: Store.ValueKind.BigInt,
+    // TODO: derived fields
+    trades: [Store.ValueKind.String],
+    createEpoch: Store.ValueKind.BigInt,
+    cancelEpoch: { optional: Store.ValueKind.BigInt },
+    deleteEpoch: { optional: Store.ValueKind.BigInt },
+    txHash: Store.ValueKind.Bytes,
+    txLogIndex: Store.ValueKind.BigInt,
+  },
   Token: {
     id: Store.ValueKind.String,
     address: Store.ValueKind.Bytes,
@@ -47,6 +73,32 @@ const EntityDefinitions = {
     symbol: { optional: Store.ValueKind.String },
     decimals: { optional: Store.ValueKind.BigInt },
     name: { optional: Store.ValueKind.String },
+    createEpoch: Store.ValueKind.BigInt,
+    txHash: Store.ValueKind.Bytes,
+  },
+  Trade: {
+    id: Store.ValueKind.String,
+    order: Store.ValueKind.String,
+    owner: Store.ValueKind.String,
+    sellVolume: Store.ValueKind.BigInt,
+    buyVolume: Store.ValueKind.BigInt,
+    tradeBatchId: Store.ValueKind.BigInt,
+    tradeEpoch: Store.ValueKind.BigInt,
+    buyToken: Store.ValueKind.String,
+    sellToken: Store.ValueKind.String,
+    createEpoch: Store.ValueKind.BigInt,
+    revertEpoch: { optional: Store.ValueKind.BigInt },
+    txHash: Store.ValueKind.Bytes,
+    txLogIndex: Store.ValueKind.BigInt,
+  },
+  User: {
+    id: Store.ValueKind.String,
+    fromBatchId: Store.ValueKind.BigInt,
+    // TODO: derived fields
+    //orders: [Store.ValueKind.String],
+    //deposits: [Store.ValueKind.String],
+    //withdrawRequests: [Store.ValueKind.String],
+    //withdrawals: [Store.ValueKind.String],
     createEpoch: Store.ValueKind.BigInt,
     txHash: Store.ValueKind.Bytes,
   },

--- a/tests/wasm/index.ts
+++ b/tests/wasm/index.ts
@@ -32,6 +32,10 @@ export class Mappings {
     this.runtime.eventHandler('onTokenListing', toEvent('TokenListing', tokenListing, meta))
   }
 
+  public onTradeReversion(tradeReversion: EventData<'TradeReversion'>, meta?: EventMetadata): void {
+    this.runtime.eventHandler('onTradeReversion', toEvent('TradeReversion', tradeReversion, meta))
+  }
+
   public getEntity<T extends EntityNames>(name: T, id: string): EntityData<T> | null {
     const entity = this.runtime.getEntity(name, id)
     if (entity === null) {

--- a/tests/wasm/runtime/host.ts
+++ b/tests/wasm/runtime/host.ts
@@ -7,10 +7,11 @@ export class Host {
   public readonly store = new Store()
   public eth = DEFAULT_ETHEREUM
 
-  public abort(message: string, fileName: string | null, line: number, column: number): void {
+  public abort(message: string | null, fileName: string | null, line: number, column: number): void {
+    const m = message || '?'
     const f = fileName || '?'
     const l = line || '?'
     const c = column || '?'
-    throw new Error(`aborted "${message}" at ${f}, line ${l}, column ${c}`)
+    throw new Error(`aborted "${m}" at ${f}, line ${l}, column ${c}`)
   }
 }

--- a/tests/wasm/runtime/index.ts
+++ b/tests/wasm/runtime/index.ts
@@ -104,7 +104,7 @@ function imports(abi: () => Abi, host: Host): WebAssembly.Imports {
   return {
     env: {
       abort: (message: Pointer, fileName: Pointer, line: number, column: number) => {
-        host.abort(readStr(message), abi().readString(fileName), line, column)
+        host.abort(abi().readString(message), abi().readString(fileName), line, column)
       },
     },
     index: {


### PR DESCRIPTION
This PR adds implementation for trade reversions. It builds on the previous partial implementation and fixes a weird issue where it appears variables aren't being captured by closures (and also does not generate a compiler error! See inline comment for more details).

This PR adds a TODO for implementing derived GraphQL fields in the testing framework. This is being tracked in #116.

### Test Plan

Added new unit tests, deploy to staging and :crossed_fingers:  