### PR TITLE
[Easy] Implement store.remove

### DIFF
--- a/tests/wasm/runtime/index.ts
+++ b/tests/wasm/runtime/index.ts
@@ -120,6 +120,9 @@ function imports(abi: () => Abi, host: Host): WebAssembly.Imports {
       'store.get': (entity: Pointer, id: Pointer) => {
         return writeEntityOrNull(host.store.get(readStr(entity), readStr(id)))
       },
+      'store.remove': (entity: Pointer, id: Pointer) => {
+        host.store.remove(readStr(entity), readStr(id))
+      },
       'store.set': (entity: Pointer, id: Pointer, data: Pointer) => {
         host.store.set(readStr(entity), readStr(id), readEntity(data))
       },

--- a/tests/wasm/runtime/store.ts
+++ b/tests/wasm/runtime/store.ts
@@ -71,4 +71,11 @@ export class Store {
     }
     map.set(id, data)
   }
+
+  public remove(entity: string, id: string): void {
+    const map = this.entities.get(entity)
+    if (map) {
+      map.delete(id)
+    }
+  }
 }


### PR DESCRIPTION
Required but unrelated to #119 this PR exposes the wasm binding to remove entities from the store in our test harness implementation.

### Test Plan

Handler code can use store.remove in unit test