### PR TITLE
[Coverage 1] Coveralls Report format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage
 
 # nyc test coverage
 .nyc_output

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
-    "assemblyscript": "^0.16.1",
+    "assemblyscript": "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3",
     "chai": "^4.2.0",
     "cli-confirm": "^1.0.1",
     "debug": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "ts:check": "tsc",
     "test": "mocha -r ts-node/register tests/**/*.test.ts",
     "test:e2e": "mocha -r ts-node/register e2e/tests/**/*.test.ts",
-    "ci": "npm run lint && npm run build && npm run ts:check && npm run test"
+    "ci": "npm run lint && npm run build && npm run ts:check && npm run test",
+    "coverage": "(cp -r src src_tmp && ts-node scripts/insertCoverageTracing.ts && yarn build && yarn test) ; (rm -rf src && mv src_tmp src)"
   },
   "dependencies": {
     "@gnosis.pm/dex-contracts": "=0.4.3",
@@ -38,12 +39,14 @@
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
+    "assemblyscript": "^0.16.1",
     "chai": "^4.2.0",
     "cli-confirm": "^1.0.1",
     "debug": "^4.2.0",
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "md5-file": "^5.0.0",
     "mocha": "^8.1.3",
     "mustache": "^4.0.1",
     "node-fetch": "^2.6.1",

--- a/tests/wasm/coverage/index.ts
+++ b/tests/wasm/coverage/index.ts
@@ -1,0 +1,5 @@
+// Each entry refers to the corresponding line in the source file. True means the line has been instrumented
+// with a trace expression, false means the line is not instrumented and thus cannot be covered (e.g. for comments, etc.)
+export type InstrumentedLines = boolean[]
+
+export { Report, recordCoverage } from './report'

--- a/tests/wasm/coverage/report.ts
+++ b/tests/wasm/coverage/report.ts
@@ -41,6 +41,7 @@ export class Report {
   }
 
   write(): void {
+    // We need to call this method from inside the WASM runtime and thus need synchronous I/O
     fs.mkdirSync(COVERAGE_FOLDER, { recursive: true })
     fs.writeFileSync(COVERAGE_FILE, JSON.stringify(this.data))
   }

--- a/tests/wasm/coverage/report.ts
+++ b/tests/wasm/coverage/report.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import md5File from 'md5-file'
+import { InstrumentedLines } from './'
+
+const COVERAGE_FOLDER = './coverage/'
+const COVERAGE_FILE = COVERAGE_FOLDER + 'report.json'
+
+interface ReportData {
+  repo_token: string | undefined
+  service_job_id: string | undefined
+  service_name: string
+  source_files: {
+    name: string
+    source_digest: string
+    coverage: (number | null)[]
+  }[]
+}
+
+export class Report {
+  data: ReportData
+
+  constructor(data?: ReportData) {
+    if (!data) {
+      data = {
+        repo_token: process.env.COVERALLS_REPO_TOKEN,
+        service_job_id: process.env.TRAVIS_BUILD_ID,
+        service_name: 'travis-ci',
+        source_files: [],
+      }
+    }
+    this.data = data
+  }
+
+  addFile(file: string, instrumentedLines: InstrumentedLines): void {
+    const source_digest = md5File.sync(file)
+    this.data.source_files.push({
+      name: file,
+      source_digest,
+      coverage: instrumentedLines.map((isInstrumented: boolean) => (isInstrumented ? 0 : null)),
+    })
+  }
+
+  write(): void {
+    fs.mkdirSync(COVERAGE_FOLDER, { recursive: true })
+    fs.writeFileSync(COVERAGE_FILE, JSON.stringify(this.data))
+  }
+}
+
+export function recordCoverage(file: string, from_line: number, to_line: number): void {
+  const report = new Report(JSON.parse(fs.readFileSync(COVERAGE_FILE, 'utf8')) as ReportData)
+  const file_report = report.data.source_files.find((f) => f.name === file)
+  if (!file_report) {
+    throw new Error('Could not find coverage entry for ' + file)
+  }
+  for (let line = from_line; line <= to_line; line++) {
+    file_report.coverage[line] = (file_report.coverage[line] || 0) + 1
+  }
+  report.write()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,6 +431,14 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assemblyscript@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.16.1.tgz#85caa1b427b4b27f7e9fcc8b08cff70262332c3e"
+  integrity sha512-btb/Q2cs42O7NaVRLDpUIb4fF+o4H4id0kjOOOzS25KCOx0voiyGBeWYqfnrOeufMQacvDNqGkjJuGkdTJIrQQ==
+  dependencies:
+    binaryen "97.0.0-nightly.20201008"
+    long "^4.0.0"
+
 "assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
   resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
@@ -529,6 +537,11 @@ binaryen@77.0.0-nightly.20190407:
   version "77.0.0-nightly.20190407"
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz#fbe4f8ba0d6bd0809a84eb519d2d5b5ddff3a7d1"
   integrity sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg==
+
+binaryen@97.0.0-nightly.20201008:
+  version "97.0.0-nightly.20201008"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-97.0.0-nightly.20201008.tgz#b9dc6fa3b92b764b66956d079190b48d2e22065f"
+  integrity sha512-GWV30FOQqz+vBIZRbc7GSasLNhh8BNLKH+2u2j5BjqM0WOEqqaP5iSj0mq72We2aVYqpBajJPI/CORY6o2RBxA==
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -2587,6 +2600,11 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+md5-file@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
+  integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This PR is the first one on a series to support code coverage for our assembly script graph handling code (see result here: https://coveralls.io/jobs/69608663)

First, we create a helper class that can create, write and manage a coverage report in the format that coveralls accepts it. I used their [documentation](https://docs.coveralls.io/api-introduction) to get the required format.

Coverage is achieved by rewriting the ASC code with [`trace` statements](https://www.assemblyscript.org/debugging.html#manual-tracing) before each meaningful expression (e.g. line of code) and implementing the `trace` call in our runtime to translate every invocation in line coverage.

The rewrite logic will add each ASC file to the empty report struct via `addFile`. The runtime will implement `trace` by calling into `recordCoverage`.

### Test Plan

At the end of the PR stack we can run `yarn coverage` to generate a report.