### PR TITLE
[Coverage 3] Instrument runtime to record coverage on trace calls

### DIFF
--- a/tests/wasm/runtime/index.ts
+++ b/tests/wasm/runtime/index.ts
@@ -12,6 +12,7 @@ import { toHex } from './convert'
 import { Event, Value } from './ethereum'
 import { Host } from './host'
 import { Entity } from './store'
+import { recordCoverage } from '../coverage'
 
 export class Runtime {
   private constructor(private abi: Abi, private host: Host, private instance: WebAssembly.Instance) {}
@@ -105,6 +106,12 @@ function imports(abi: () => Abi, host: Host): WebAssembly.Imports {
     env: {
       abort: (message: Pointer, fileName: Pointer, line: number, column: number) => {
         host.abort(abi().readString(message), abi().readString(fileName), line, column)
+      },
+      trace: (fileNamePtr: Pointer, from_line: number, to_line: number) => {
+        const fileName = abi().readString(fileNamePtr)
+        if (fileName) {
+          recordCoverage(fileName, from_line, to_line)
+        }
       },
     },
     index: {

--- a/tests/wasm/runtime/index.ts
+++ b/tests/wasm/runtime/index.ts
@@ -105,7 +105,7 @@ function imports(abi: () => Abi, host: Host): WebAssembly.Imports {
   return {
     env: {
       abort: (message: Pointer, fileName: Pointer, line: number, column: number) => {
-        host.abort(abi().readString(message), abi().readString(fileName), line, column)
+        host.abort(readStr(message), readStr(fileName), line, column)
       },
       trace: (fileNamePtr: Pointer, from_line: number, to_line: number) => {
         const fileName = abi().readString(fileNamePtr)


### PR DESCRIPTION
Tiny PR that implements the `trace` call in our fake runtime and delegates to our reportin module to record that the given file/lines have been visited.


### Test Plan

At the end of the PR stack we can run `yarn coverage` to generate a report.