### PR TITLE
Fix Travis

### DIFF
--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,7 +13,7 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  docker-compose logs graph-node
+  docker_compose logs -- graph-node
   docker_compose rm --stop -f
 }
 trap on_exit EXIT

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,7 +13,7 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  docker_compose logs
+  docker-compose logs graph-node
   docker_compose rm --stop -f
 }
 trap on_exit EXIT

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,7 +13,7 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  docker_compose logs graph-node
+  docker_compose logs
   docker_compose rm --stop -f
 }
 trap on_exit EXIT

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,7 +13,7 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  #docker_compose logs graph-node
+  docker_compose logs graph-node
   docker_compose rm --stop -f
 }
 trap on_exit EXIT

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -12,7 +12,7 @@ docker_compose() {
 }
 
 on_exit() {
-  unset -e
+  set +e
   echo "## Shutting down local Graph node"
   docker_compose logs graph-node 
   docker_compose rm --stop -f

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,8 +13,8 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  docker_compose logs -- graph-node
-  docker_compose rm --stop -f
+  docker_compose logs
+  #docker_compose rm --stop -f
 }
 trap on_exit EXIT
 

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -12,9 +12,10 @@ docker_compose() {
 }
 
 on_exit() {
+  unset -e
   echo "## Shutting down local Graph node"
-  docker_compose logs
-  #docker_compose rm --stop -f
+  docker_compose logs graph-node 
+  docker_compose rm --stop -f
 }
 trap on_exit EXIT
 

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -13,7 +13,7 @@ docker_compose() {
 
 on_exit() {
   echo "## Shutting down local Graph node"
-  docker_compose logs graph-node
+  #docker_compose logs graph-node
   docker_compose rm --stop -f
 }
 trap on_exit EXIT


### PR DESCRIPTION
It seems like `docker-compose logs` is erroring with 

> Failed to execute script docker-compose

cf. https://travis-ci.com/github/gnosis/dex-subgraph/jobs/407146602

I was not able to find the root cause nor able reproduce it locally on my Mac but it seems reasonable to not fail travis if either `docker-compose logs` of `docker-compose stop` fails, therefore this PR is unsetting the `-e` flag.