### PR TITLE
Record total sell volume per token

### DIFF
--- a/e2e/tests/subgraph.test.ts
+++ b/e2e/tests/subgraph.test.ts
@@ -133,4 +133,26 @@ describe('Subgraph', function () {
       }
     }
   })
+
+  it('should contain tokens with cumulative sell volume', async () => {
+    const { orders } = (await query(`{
+      orders {
+        soldVolume
+        sellToken {
+          sellVolume
+        }
+      }
+    }`)) as {
+      orders: {
+        soldVolume: string
+        sellToken: {
+          sellVolume: string
+        }
+      }[]
+    }
+
+    for (const order of orders) {
+      expect(order.soldVolume).to.equal(order.sellToken.sellVolume)
+    }
+  })
 })

--- a/e2e/tests/subgraph.test.ts
+++ b/e2e/tests/subgraph.test.ts
@@ -136,7 +136,7 @@ describe('Subgraph', function () {
 
   it('should contain tokens with cumulative sell volume', async () => {
     const { orders } = (await query(`{
-      orders {
+      orders(where: {soldVolume_gt: 0}) {
         soldVolume
         sellToken {
           sellVolume

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,6 +22,9 @@ type Token @entity {
   # balances: [Balance!]! @derivedFrom(field: "token") // TODO: Pending mapping
   # deposits: [Deposit!]! @derivedFrom(field: "token") // TODO: Disabled for now, until we sort out how to relate it better
 
+  # Cumulative sell volume
+  sellVolume: BigInt!
+
   # Audit Dates
   createEpoch: BigInt!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,7 +22,7 @@ type Token @entity {
   # balances: [Balance!]! @derivedFrom(field: "token") // TODO: Pending mapping
   # deposits: [Deposit!]! @derivedFrom(field: "token") // TODO: Disabled for now, until we sort out how to relate it better
 
-  # Cumulative sell volume
+  "Cumulative sell volume"
   sellVolume: BigInt!
 
   # Audit Dates

--- a/src/mappings/tokens.ts
+++ b/src/mappings/tokens.ts
@@ -51,6 +51,9 @@ export function onTokenListing(event: TokenListingEvent): void {
   // Transaction
   token.txHash = event.transaction.hash
 
+  //Volume
+  token.sellVolume = BigInt.fromI32(0)
+
   token.save()
 }
 
@@ -61,4 +64,16 @@ export function getTokenById(tokenId: i32): Token {
     throw new Error("Token doesn't exist: " + id)
   }
   return tokenOpt!
+}
+
+export function incrementSellVolume(tokenId: i32, amount: BigInt): void {
+  let token = getTokenById(tokenId)
+  token.sellVolume += amount
+  token.save()
+}
+
+export function decrementSellVolume(tokenId: i32, amount: BigInt): void {
+  let token = getTokenById(tokenId)
+  token.sellVolume -= amount
+  token.save()
 }

--- a/src/mappings/trade_reversions.ts
+++ b/src/mappings/trade_reversions.ts
@@ -5,6 +5,7 @@ import { createSolution, getSolutionById } from './solution'
 import { updateOrderOnTradeReversion } from './orders'
 import { getBatchById } from './batch'
 import { getTradeById } from './trades'
+import { decrementSellVolume } from './tokens'
 
 export function onTradeReversion(event: TradeReversionEvent): void {
   let batchId = getBatchId(event).minus(BigInt.fromI32(1))
@@ -15,6 +16,9 @@ export function onTradeReversion(event: TradeReversionEvent): void {
   let priceId = toPriceId(event.params.sellToken, batchId)
   log.info('[onTradeReversion] Remove Price: {}', [priceId])
   store.remove('Price', priceId)
+
+  // Delete token volume associated with that trade
+  decrementSellVolume(event.params.sellToken, event.params.executedSellAmount)
 
   let trades = solution.trades
   if (trades.length === 0) {

--- a/src/mappings/trades.ts
+++ b/src/mappings/trades.ts
@@ -5,6 +5,7 @@ import { toOrderId, toEventId, batchIdToEndOfBatchEpoch, getBatchId } from '../u
 import { updateOrderOnNewTrade, getOrderById } from './orders'
 import { createSolutionOrAddTrade } from './solution'
 import { createOrUpdatePrice } from './prices'
+import { incrementSellVolume } from './tokens'
 
 export function getTradeById(tradeId: string): Trade {
   let tradeOpt = Trade.load(tradeId)
@@ -48,8 +49,11 @@ export function onTrade(event: TradeEvent): void {
   // Create trade
   let trade = _createTrade(orderId, event)
 
-  // Update traces
+  // Update prices
   createOrUpdatePrice(event.params.sellToken, trade, event)
+
+  // Update trading volume of token
+  incrementSellVolume(event.params.sellToken, event.params.executedSellAmount)
 
   // Update order (traded amounts totals)
   updateOrderOnNewTrade(orderId, trade)

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -27,6 +27,7 @@ describe('onOrderPlacement', function () {
       symbol: 'OWL',
       decimals: 18n,
       name: 'Token OWL',
+      sellVolume: 0n,
       createEpoch: 0n,
       txHash: `0x${'00'.repeat(32)}`,
     })
@@ -37,6 +38,7 @@ describe('onOrderPlacement', function () {
       symbol: 'GNO',
       decimals: 18n,
       name: 'GNO Token',
+      sellVolume: 0n,
       createEpoch: 0n,
       txHash: `0x${'01'.repeat(32)}`,
     })

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai'
+import { Mappings } from './wasm'
+
+describe('onOrderPlacement', function () {
+  let mappings: Mappings
+
+  const user = `0x${'1337'.repeat(10)}`
+  const index = 42
+  const orderUid = `${user}-${index}`
+  const maxSellAmount = 200000n * 10n ** 18n
+  const minReceiveAmount = 1000n * 10n ** 18n
+  const buyToken = 1n
+  const sellToken = 2n
+  const validFrom = 13n
+  const validUntil = 17n
+
+  const txHash = `0x${'01'.repeat(32)}`
+  const logIndex = 1n
+  const timestamp = 10n * 300n + 42n
+
+  beforeEach(async function () {
+    mappings = await Mappings.load()
+    mappings.setEntity('Token', `${sellToken}`, {
+      id: `${sellToken}`,
+      address: `0x${'00'.repeat(20)}`,
+      fromBatchId: 0n,
+      symbol: 'OWL',
+      decimals: 18n,
+      name: 'Token OWL',
+      createEpoch: 0n,
+      txHash: `0x${'00'.repeat(32)}`,
+    })
+    mappings.setEntity('Token', `${buyToken}`, {
+      id: `${buyToken}`,
+      address: `0x${'00'.repeat(20)}`,
+      fromBatchId: 0n,
+      symbol: 'GNO',
+      decimals: 18n,
+      name: 'GNO Token',
+      createEpoch: 0n,
+      txHash: `0x${'01'.repeat(32)}`,
+    })
+
+    mappings.onOrderPlacement(
+      {
+        owner: user,
+        index,
+        validFrom,
+        validUntil,
+        buyToken,
+        sellToken,
+        priceNumerator: minReceiveAmount,
+        priceDenominator: maxSellAmount,
+      },
+      {
+        block: { timestamp },
+        logIndex,
+        transaction: { hash: txHash },
+      },
+    )
+  })
+
+  it('create an order entity', async function () {
+    const order = mappings.getEntity('Order', orderUid)
+    expect(order).to.exist
+    expect(order).to.deep.equal({
+      id: orderUid,
+      owner: user,
+      orderId: index,
+      fromBatchId: validFrom,
+      fromEpoch: validFrom * 300n,
+      untilBatchId: validUntil,
+      untilEpoch: validUntil * 300n,
+      buyToken: `${buyToken}`,
+      sellToken: `${sellToken}`,
+      priceNumerator: minReceiveAmount,
+      priceDenominator: maxSellAmount,
+      maxSellAmount,
+      minReceiveAmount,
+      soldVolume: 0n,
+      boughtVolume: 0n,
+      createEpoch: timestamp,
+      cancelEpoch: null,
+      deleteEpoch: null,
+      txHash,
+      txLogIndex: logIndex,
+    })
+  })
+
+  it('create a user entity', async function () {
+    const batch = mappings.getEntity('User', user)
+    expect(batch).to.exist
+    expect(batch).to.deep.equal({
+      id: user,
+      fromBatchId: timestamp / 300n,
+      createEpoch: timestamp,
+      txHash,
+    })
+  })
+})

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -98,3 +98,110 @@ describe('onOrderPlacement', function () {
     })
   })
 })
+
+describe('onOrderCancellation', function () {
+  let mappings: Mappings
+
+  const user = `0x${'1337'.repeat(10)}`
+  const index = 42
+  const orderUid = `${user}-${index}`
+
+  const txHash = `0x${'02'.repeat(32)}`
+  const logIndex = 1n
+  const timestamp = 10n * 300n + 42n
+
+  beforeEach(async function () {
+    mappings = await Mappings.load()
+    mappings.setEntity('Order', orderUid, orderFixture(user, index))
+    mappings.onOrderCancellation(
+      {
+        owner: user,
+        index,
+      },
+      {
+        block: { timestamp },
+        logIndex,
+        transaction: { hash: txHash },
+      },
+    )
+  })
+
+  it('sets the cancellation epoch', async function () {
+    const order = mappings.getEntity('Order', orderUid)
+    expect(order!.cancelEpoch).to.equal(timestamp)
+  })
+
+  it('updates the valid until batchId', async function () {
+    const order = mappings.getEntity('Order', orderUid)
+    const validUntil = timestamp / 300n - 1n
+
+    expect(order!.untilBatchId).to.equal(validUntil)
+    expect(order!.untilEpoch).to.equal(validUntil * 300n)
+  })
+})
+
+describe('orderDeletion', function () {
+  let mappings: Mappings
+
+  const user = `0x${'1337'.repeat(10)}`
+  const index = 42
+  const orderUid = `${user}-${index}`
+
+  const txHash = `0x${'02'.repeat(32)}`
+  const logIndex = 1n
+  const timestamp = 10n * 300n + 42n
+
+  beforeEach(async function () {
+    mappings = await Mappings.load()
+    mappings.setEntity('Order', orderUid, orderFixture(user, index))
+    mappings.onOrderDeletion(
+      {
+        owner: user,
+        index,
+      },
+      {
+        block: { timestamp },
+        logIndex,
+        transaction: { hash: txHash },
+      },
+    )
+  })
+
+  it('sets the deletion epoch', async function () {
+    const order = mappings.getEntity('Order', orderUid)
+    expect(order!.deleteEpoch).to.equal(timestamp)
+  })
+
+  it('updates the valid until batchId', async function () {
+    const order = mappings.getEntity('Order', orderUid)
+    const validUntil = timestamp / 300n - 1n
+
+    expect(order!.untilBatchId).to.equal(validUntil)
+    expect(order!.untilEpoch).to.equal(validUntil * 300n)
+  })
+})
+
+function orderFixture(user: string, orderId: number) {
+  return {
+    id: `${user}-${orderId}`,
+    owner: user,
+    orderId,
+    fromBatchId: 0n,
+    fromEpoch: 0n,
+    untilBatchId: 42n,
+    untilEpoch: 42n * 300n,
+    buyToken: '1',
+    sellToken: '0',
+    priceNumerator: 200000n * 10n ** 18n,
+    priceDenominator: 1000n * 10n ** 18n,
+    maxSellAmount: 200000n * 10n ** 18n,
+    minReceiveAmount: 1000n * 10n ** 18n,
+    soldVolume: 0n,
+    boughtVolume: 0n,
+    createEpoch: 0n,
+    cancelEpoch: null,
+    deleteEpoch: null,
+    txHash: `0x${'0f'.repeat(32)}`,
+    txLogIndex: 0n,
+  }
+}

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -41,6 +41,7 @@ describe('onTokenListing', function () {
       symbol: 'TEST',
       decimals: 18n,
       name: 'Test Token',
+      sellVolume: 0n,
       createEpoch: 42n * 300n,
       txHash: `0x${'42'.repeat(32)}`,
     })

--- a/tests/trade_reversions.test.ts
+++ b/tests/trade_reversions.test.ts
@@ -4,7 +4,7 @@ import { ValueKind } from './wasm/runtime/ethereum'
 
 describe('onTradeReversion', () => {
   const user = `0x${'1337'.repeat(10)}`
-  const orderId = 1337n
+  const orderId = 1337
   const orderUid = `${user}-${orderId}`
   const tradeTxHash = `0x${'01'.repeat(32)}`
   const reversionTxHash = `0x${'02'.repeat(32)}`

--- a/tests/trade_reversions.test.ts
+++ b/tests/trade_reversions.test.ts
@@ -28,6 +28,7 @@ describe('onTradeReversion', () => {
       symbol: 'OWL',
       decimals: 18n,
       name: 'Token OWL',
+      sellVolume,
       createEpoch: 0n,
       txHash: tradeTxHash,
     })
@@ -138,6 +139,12 @@ describe('onTradeReversion', () => {
     const state = await createFixturesAndMakeTrade()
     const price = state.getEntity('Price', priceId)
     expect(price).to.not.exist
+  })
+
+  it('reduces the total sellAmount of the token', async () => {
+    const state = await createFixturesAndMakeTrade()
+    const token = state.getEntity('Token', sellToken)
+    expect(token!.sellVolume).to.equal(0n)
   })
 
   it('reverts the trade', async () => {

--- a/tests/trades.test.ts
+++ b/tests/trades.test.ts
@@ -26,6 +26,7 @@ describe('onTrade', function () {
       symbol: 'OWL',
       decimals: 18n,
       name: 'Token OWL',
+      sellVolume: 0n,
       createEpoch: 0n,
       txHash: `0x${'00'.repeat(32)}`,
     })
@@ -162,5 +163,10 @@ describe('onTrade', function () {
       createEpoch: timestamp,
       txHash,
     })
+  })
+
+  it('updates total volume of sell token', async () => {
+    const token = mappings.getEntity('Token', sellToken)
+    expect(token!.sellVolume).to.equal(100000n * 10n ** 18n)
   })
 })

--- a/tests/trades.test.ts
+++ b/tests/trades.test.ts
@@ -6,7 +6,7 @@ describe('onTrade', function () {
   let mappings: Mappings
 
   const user = `0x${'1337'.repeat(10)}`
-  const orderId = 1337n
+  const orderId = 1337
   const orderUid = `${user}-${orderId}`
   const txHash = `0x${'01'.repeat(32)}`
   const logIndex = 1n

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -149,6 +149,7 @@ const EntityDefinitions = {
     symbol: { optional: Store.ValueKind.String },
     decimals: { optional: Store.ValueKind.BigInt },
     name: { optional: Store.ValueKind.String },
+    sellVolume: Store.ValueKind.BigInt,
     createEpoch: Store.ValueKind.BigInt,
     txHash: Store.ValueKind.Bytes,
   },

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -10,6 +10,16 @@ const EventDefinitions = {
     amount: Ethereum.ValueKind.Uint,
     batchId: Ethereum.ValueKind.Uint,
   },
+  OrderPlacement: {
+    owner: Ethereum.ValueKind.Address,
+    index: Ethereum.ValueKind.Uint,
+    buyToken: Ethereum.ValueKind.Uint,
+    sellToken: Ethereum.ValueKind.Uint,
+    validFrom: Ethereum.ValueKind.Uint,
+    validUntil: Ethereum.ValueKind.Uint,
+    priceNumerator: Ethereum.ValueKind.Uint,
+    priceDenominator: Ethereum.ValueKind.Uint,
+  },
   SolutionSubmission: {
     submitter: Ethereum.ValueKind.Address,
     utility: Ethereum.ValueKind.Uint,
@@ -83,7 +93,7 @@ const EntityDefinitions = {
   Order: {
     id: Store.ValueKind.String,
     owner: Store.ValueKind.String,
-    orderId: Store.ValueKind.BigInt,
+    orderId: Store.ValueKind.Int,
     fromBatchId: Store.ValueKind.BigInt,
     fromEpoch: Store.ValueKind.BigInt,
     untilBatchId: Store.ValueKind.BigInt,

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -10,6 +10,14 @@ const EventDefinitions = {
     amount: Ethereum.ValueKind.Uint,
     batchId: Ethereum.ValueKind.Uint,
   },
+  OrderCancellation: {
+    owner: Ethereum.ValueKind.Address,
+    index: Ethereum.ValueKind.Uint,
+  },
+  OrderDeletion: {
+    owner: Ethereum.ValueKind.Address,
+    index: Ethereum.ValueKind.Uint,
+  },
   OrderPlacement: {
     owner: Ethereum.ValueKind.Address,
     index: Ethereum.ValueKind.Uint,

--- a/tests/wasm/index.ts
+++ b/tests/wasm/index.ts
@@ -28,6 +28,10 @@ export class Mappings {
     this.runtime.eventHandler('onDeposit', toEvent('Deposit', deposit, meta))
   }
 
+  public onOrderPlacement(deposit: EventData<'OrderPlacement'>, meta?: EventMetadata): void {
+    this.runtime.eventHandler('onOrderPlacement', toEvent('OrderPlacement', deposit, meta))
+  }
+
   public onTokenListing(tokenListing: EventData<'TokenListing'>, meta?: EventMetadata): void {
     this.runtime.eventHandler('onTokenListing', toEvent('TokenListing', tokenListing, meta))
   }

--- a/tests/wasm/index.ts
+++ b/tests/wasm/index.ts
@@ -28,8 +28,16 @@ export class Mappings {
     this.runtime.eventHandler('onDeposit', toEvent('Deposit', deposit, meta))
   }
 
-  public onOrderPlacement(deposit: EventData<'OrderPlacement'>, meta?: EventMetadata): void {
-    this.runtime.eventHandler('onOrderPlacement', toEvent('OrderPlacement', deposit, meta))
+  public onOrderCancellation(order: EventData<'OrderCancellation'>, meta?: EventMetadata): void {
+    this.runtime.eventHandler('onOrderCancellation', toEvent('OrderCancellation', order, meta))
+  }
+
+  public onOrderDeletion(order: EventData<'OrderDeletion'>, meta?: EventMetadata): void {
+    this.runtime.eventHandler('onOrderDeletion', toEvent('OrderDeletion', order, meta))
+  }
+
+  public onOrderPlacement(order: EventData<'OrderPlacement'>, meta?: EventMetadata): void {
+    this.runtime.eventHandler('onOrderPlacement', toEvent('OrderPlacement', order, meta))
   }
 
   public onTokenListing(tokenListing: EventData<'TokenListing'>, meta?: EventMetadata): void {


### PR DESCRIPTION
This PR adds functionality to compute the total sell Volume of a specific token. This metric is useful for networks for which we don't have Dune analytics (e.g. xDAI). It can also be used to query volume of a token over a specific period of time (e.g. last 24h by using [time travel queries](https://thegraph.com/docs/graphql-api#time-travel-queries).

Each trade event increments the total volume of its sell token and each trade reversion decrements it.

In a next PR I'm planning to also start collecting "global stats" such as total OWL volume, fees, number of trades, batches etc.

### Test Plan

Updated unit tests and integration tests.