### PR TITLE
Global stats

### DIFF
--- a/e2e/tests/subgraph.test.ts
+++ b/e2e/tests/subgraph.test.ts
@@ -155,4 +155,33 @@ describe('Subgraph', function () {
       expect(order.soldVolume).to.equal(order.sellToken.sellVolume)
     }
   })
+
+  it('should contain latest stats', async () => {
+    const { stats } = (await query(`{
+      stats(id: "latest") {
+        utilityInOwl
+        volumeInOwl
+        owlBurnt
+        settledBatchCount
+        settledTradeCount
+        listedTokens
+      }
+    }`)) as {
+      stats: {
+        volumeInOwl: string
+        utilityInOwl: string
+        owlBurnt: string
+        settledBatchCount: string
+        settledTradeCount: string
+        listedTokens: string
+      }
+    }
+
+    expect(stats.volumeInOwl).to.equal('40020020020020020000')
+    expect(stats.utilityInOwl).to.equal('1997000999999950199701198')
+    expect(stats.owlBurnt).to.equal('20010010010010010')
+    expect(stats.settledBatchCount).to.equal(1)
+    expect(stats.settledTradeCount).to.equal(2)
+    expect(stats.listedTokens).to.equal(2)
+  })
 })

--- a/schema.graphql
+++ b/schema.graphql
@@ -251,11 +251,11 @@ type Stats @entity {
   owlBurnt: BigInt!
 
   # The total number of settled batches
-  settledBatchCount: BigInt!
+  settledBatchCount: Int!
 
   # The total number of settled trades
-  settledTradeCount: BigInt!
+  settledTradeCount: Int!
 
   # The number of listed tokens
-  listedTokens: BigInt!
+  listedTokens: Int!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -238,24 +238,27 @@ type Solution @entity {
   txLogIndex: BigInt!
 }
 
+"""
+A type collecting global stats about this instance of Gnosis Protocol
+"""
 type Stats @entity {
   id: ID!
 
-  # The total volume denominated in OWL (all sell amounts combined)
+  "The total volume denominated in OWL (all sell amounts combined)"
   volumeInOwl: BigInt!
 
-  # The total trader surplus in OWL
+  "The total trader surplus in OWL"
   utilityInOwl: BigInt!
 
-  # The total amount of OWL burnt (equivalent to fees rewarded to solvers)
+  "The total amount of OWL burnt (equivalent to fees rewarded to solvers)"
   owlBurnt: BigInt!
 
-  # The total number of settled batches
+  "The total number of settled batches"
   settledBatchCount: Int!
 
-  # The total number of settled trades
+  "The total number of settled trades"
   settledTradeCount: Int!
 
-  # The number of listed tokens
+  "The number of listed tokens"
   listedTokens: Int!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -237,3 +237,25 @@ type Solution @entity {
   txHash: Bytes!
   txLogIndex: BigInt!
 }
+
+type Stats @entity {
+  id: ID!
+
+  # The total volume denominated in OWL (all sell amounts combined)
+  volumeInOwl: BigInt!
+
+  # The total trader surplus in OWL
+  utilityInOwl: BigInt!
+
+  # The total amount of OWL burnt (equivalent to fees rewarded to solvers)
+  owlBurnt: BigInt!
+
+  # The total number of settled batches
+  settledBatchCount: BigInt!
+
+  # The total number of settled trades
+  settledTradeCount: BigInt!
+
+  # The number of listed tokens
+  listedTokens: BigInt!
+}

--- a/src/mappings/solution.ts
+++ b/src/mappings/solution.ts
@@ -3,6 +3,7 @@ import { Trade, Solution, Batch } from '../../generated/schema'
 import { createBatchIfNotCreated } from './batch'
 import { SolutionSubmission as SolutionEvent } from '../../generated/BatchExchange/BatchExchange'
 import { createUserIfNotCreated } from './users'
+import { addSolutionToStats } from './stats'
 import { getBatchById } from './batch'
 import { getBatchId } from '../utils'
 
@@ -11,6 +12,9 @@ export function onSolutionSubmission(event: SolutionEvent): void {
   let batch = getBatchById(getBatchId(event) - BigInt.fromI32(1))
   log.info('[onSolutionSubmission] Updating solution for batch {}', [batch.id])
   let solution = getSolutionById(batch.solution)
+
+  // Stats
+  addSolutionToStats(event.params.utility, event.params.burntFees, solution.trades.length)
 
   // Solution details
   solution.solver = event.transaction.from.toHex()

--- a/src/mappings/stats.ts
+++ b/src/mappings/stats.ts
@@ -3,7 +3,7 @@ import { Stats } from '../../generated/schema'
 
 export function addTokenToStats(): void {
   let stats = getOrCreateStats()
-  stats.listedTokens += BigInt.fromI32(1)
+  stats.listedTokens += 1
   stats.save()
 }
 
@@ -13,8 +13,8 @@ export function addSolutionToStats(utility: BigInt, owlBurnt: BigInt, tradeCount
   stats.volumeInOwl += BigInt.fromI32(2000).times(owlBurnt)
   stats.utilityInOwl += utility
   stats.owlBurnt += owlBurnt
-  stats.settledBatchCount += BigInt.fromI32(1)
-  stats.settledTradeCount += BigInt.fromI32(tradeCount)
+  stats.settledBatchCount += 1
+  stats.settledTradeCount += tradeCount
   stats.save()
 }
 
@@ -24,8 +24,8 @@ export function revertSolutionFromStats(utility: BigInt, owlBurnt: BigInt, trade
   stats.volumeInOwl -= BigInt.fromI32(2000).times(owlBurnt)
   stats.utilityInOwl -= utility
   stats.owlBurnt -= owlBurnt
-  stats.settledBatchCount -= BigInt.fromI32(1)
-  stats.settledTradeCount -= BigInt.fromI32(tradeCount)
+  stats.settledBatchCount -= 1
+  stats.settledTradeCount -= tradeCount
   stats.save()
 }
 
@@ -37,9 +37,9 @@ function getOrCreateStats(): Stats {
     stats.volumeInOwl = BigInt.fromI32(0)
     stats.utilityInOwl = BigInt.fromI32(0)
     stats.owlBurnt = BigInt.fromI32(0)
-    stats.settledBatchCount = BigInt.fromI32(0)
-    stats.settledTradeCount = BigInt.fromI32(0)
-    stats.listedTokens = BigInt.fromI32(0)
+    stats.settledBatchCount = 0
+    stats.settledTradeCount = 0
+    stats.listedTokens = 0
   }
   return stats!
 }

--- a/src/mappings/stats.ts
+++ b/src/mappings/stats.ts
@@ -1,0 +1,45 @@
+import { log, BigInt } from '@graphprotocol/graph-ts'
+import { Stats } from '../../generated/schema'
+
+export function addTokenToStats(): void {
+  let stats = getOrCreateStats()
+  stats.listedTokens += BigInt.fromI32(1)
+  stats.save()
+}
+
+export function addSolutionToStats(utility: BigInt, owlBurnt: BigInt, tradeCount: u32): void {
+  let stats = getOrCreateStats()
+  // We burn half of the 0.1% trading fee, therefore volume is 2000 * owl burn
+  stats.volumeInOwl += BigInt.fromI32(2000).times(owlBurnt)
+  stats.utilityInOwl += utility
+  stats.owlBurnt += owlBurnt
+  stats.settledBatchCount += BigInt.fromI32(1)
+  stats.settledTradeCount += BigInt.fromI32(tradeCount)
+  stats.save()
+}
+
+export function revertSolutionFromStats(utility: BigInt, owlBurnt: BigInt, tradeCount: u32): void {
+  let stats = getOrCreateStats()
+  // We burn half of the 0.1% trading fee, therefore volume is 2000 * owl burn
+  stats.volumeInOwl -= BigInt.fromI32(2000).times(owlBurnt)
+  stats.utilityInOwl -= utility
+  stats.owlBurnt -= owlBurnt
+  stats.settledBatchCount -= BigInt.fromI32(1)
+  stats.settledTradeCount -= BigInt.fromI32(tradeCount)
+  stats.save()
+}
+
+function getOrCreateStats(): Stats {
+  let stats = Stats.load('latest')
+  if (!stats) {
+    log.info('[Stats] Creating new stats', [])
+    stats = new Stats('latest')
+    stats.volumeInOwl = BigInt.fromI32(0)
+    stats.utilityInOwl = BigInt.fromI32(0)
+    stats.owlBurnt = BigInt.fromI32(0)
+    stats.settledBatchCount = BigInt.fromI32(0)
+    stats.settledTradeCount = BigInt.fromI32(0)
+    stats.listedTokens = BigInt.fromI32(0)
+  }
+  return stats!
+}

--- a/src/mappings/tokens.ts
+++ b/src/mappings/tokens.ts
@@ -3,6 +3,7 @@ import { Token } from '../../generated/schema'
 import { TokenListing as TokenListingEvent } from '../../generated/BatchExchange/BatchExchange'
 import { Erc20 } from '../../generated/BatchExchange/Erc20'
 import { epochToBatchId } from '../utils'
+import { addTokenToStats } from './stats'
 
 export function onTokenListing(event: TokenListingEvent): void {
   let params = event.params
@@ -55,6 +56,8 @@ export function onTokenListing(event: TokenListingEvent): void {
   token.sellVolume = BigInt.fromI32(0)
 
   token.save()
+
+  addTokenToStats()
 }
 
 export function getTokenById(tokenId: i32): Token {

--- a/src/mappings/trade_reversions.ts
+++ b/src/mappings/trade_reversions.ts
@@ -6,6 +6,7 @@ import { updateOrderOnTradeReversion } from './orders'
 import { getBatchById } from './batch'
 import { getTradeById } from './trades'
 import { decrementSellVolume } from './tokens'
+import { revertSolutionFromStats } from './stats'
 
 export function onTradeReversion(event: TradeReversionEvent): void {
   let batchId = getBatchId(event).minus(BigInt.fromI32(1))
@@ -43,6 +44,9 @@ export function onTradeReversion(event: TradeReversionEvent): void {
   log.info('[onTradeReversion] Revert Solution: {}', [solution.id])
   solution.revertEpoch = event.block.timestamp
   solution.save()
+
+  // Revert global stats
+  revertSolutionFromStats(solution.utility!, solution.feeReward!, trades.length)
 
   // Replace solution on batch
   batch.lastRevertEpoch = event.block.timestamp

--- a/tests/solutions.test.ts
+++ b/tests/solutions.test.ts
@@ -27,19 +27,11 @@ describe('onSolutionSubmission', function () {
     mappings.setEntity('Solution', solutionId, {
       id: solutionId,
       batch: `${batchId}`,
-<<<<<<< HEAD
       solver: `0x${'ff'.repeat(20)}`,
       feeReward: 0n,
       objectiveValue: 0n,
       utility: 0n,
       trades: ["t1", "t2"],
-=======
-      solver: null,
-      feeReward: null,
-      objectiveValue: null,
-      utility: null,
-      trades: ['t1', 't2'],
->>>>>>> e2e tests
       createEpoch: timestamp,
       revertEpoch: null,
       txHash,

--- a/tests/solutions.test.ts
+++ b/tests/solutions.test.ts
@@ -27,11 +27,19 @@ describe('onSolutionSubmission', function () {
     mappings.setEntity('Solution', solutionId, {
       id: solutionId,
       batch: `${batchId}`,
+<<<<<<< HEAD
       solver: `0x${'ff'.repeat(20)}`,
       feeReward: 0n,
       objectiveValue: 0n,
       utility: 0n,
       trades: ["t1", "t2"],
+=======
+      solver: null,
+      feeReward: null,
+      objectiveValue: null,
+      utility: null,
+      trades: ['t1', 't2'],
+>>>>>>> e2e tests
       createEpoch: timestamp,
       revertEpoch: null,
       txHash,
@@ -69,7 +77,7 @@ describe('onSolutionSubmission', function () {
     expect(stats!.volumeInOwl).to.equal(burntFees * 2000n)
     expect(stats!.utilityInOwl).to.equal(utility)
     expect(stats!.owlBurnt).to.equal(burntFees)
-    expect(stats!.settledBatchCount).to.equal(1n)
-    expect(stats!.settledTradeCount).to.equal(2n)
+    expect(stats!.settledBatchCount).to.equal(1)
+    expect(stats!.settledTradeCount).to.equal(2)
   })
 })

--- a/tests/solutions.test.ts
+++ b/tests/solutions.test.ts
@@ -31,7 +31,7 @@ describe('onSolutionSubmission', function () {
       feeReward: 0n,
       objectiveValue: 0n,
       utility: 0n,
-      trades: [],
+      trades: ["t1", "t2"],
       createEpoch: timestamp,
       revertEpoch: null,
       txHash,
@@ -61,5 +61,15 @@ describe('onSolutionSubmission', function () {
     expect(solution!.utility).to.equal(utility)
     expect(solution!.feeReward).to.equal(burntFees)
     expect(solution!.objectiveValue).to.equal(utility + burntFees - disregardedUtility)
+  })
+
+  it('updates global stats', async function () {
+    const stats = mappings.getEntity('Stats', 'latest')
+    expect(stats).to.exist
+    expect(stats!.volumeInOwl).to.equal(burntFees * 2000n)
+    expect(stats!.utilityInOwl).to.equal(utility)
+    expect(stats!.owlBurnt).to.equal(burntFees)
+    expect(stats!.settledBatchCount).to.equal(1n)
+    expect(stats!.settledTradeCount).to.equal(2n)
   })
 })

--- a/tests/solutions.test.ts
+++ b/tests/solutions.test.ts
@@ -31,7 +31,7 @@ describe('onSolutionSubmission', function () {
       feeReward: 0n,
       objectiveValue: 0n,
       utility: 0n,
-      trades: ["t1", "t2"],
+      trades: ['t1', 't2'],
       createEpoch: timestamp,
       revertEpoch: null,
       txHash,

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -63,4 +63,17 @@ describe('onTokenListing', function () {
       decimals: null,
     })
   })
+
+  it('updates global stats', async () => { 
+    const mappings = await Mappings.load()
+    mappings.setCallHandler(() => null)
+
+    mappings.onTokenListing({
+      id: 0,
+      token: `0x${'00'.repeat(20)}`,
+    })
+
+    const stats = mappings.getEntity('Stats', 'latest')
+    expect(stats!.listedTokens).to.equal(1n)
+  })
 })

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -64,7 +64,7 @@ describe('onTokenListing', function () {
     })
   })
 
-  it('updates global stats', async () => { 
+  it('updates global stats', async () => {
     const mappings = await Mappings.load()
     mappings.setCallHandler(() => null)
 
@@ -74,6 +74,6 @@ describe('onTokenListing', function () {
     })
 
     const stats = mappings.getEntity('Stats', 'latest')
-    expect(stats!.listedTokens).to.equal(1n)
+    expect(stats!.listedTokens).to.equal(1)
   })
 })

--- a/tests/trade_reversions.test.ts
+++ b/tests/trade_reversions.test.ts
@@ -100,6 +100,15 @@ describe('onTradeReversion', () => {
       createEpoch: tradeTimestamp,
       txHash: tradeTxHash,
     })
+    mappings.setEntity('Stats', 'latest', {
+      id: 'latest',
+      volumeInOwl: 1337n * 2000n,
+      utilityInOwl: 42n,
+      owlBurnt: 1337n,
+      settledBatchCount: 1n,
+      settledTradeCount: 1n,
+      listedTokens: 2n,
+    })
 
     mappings.onTradeReversion(
       {
@@ -174,5 +183,15 @@ describe('onTradeReversion', () => {
       txHash: reversionTxHash,
       txLogIndex: logIndex,
     })
+  })
+
+  it('reverts global trading stats', async () => {
+    const state = await createFixturesAndMakeTrade()
+    const stats = state.getEntity('Stats', 'latest')
+    expect(stats!.volumeInOwl).to.equal(0n)
+    expect(stats!.utilityInOwl).to.equal(0n)
+    expect(stats!.owlBurnt).to.equal(0n)
+    expect(stats!.settledBatchCount).to.equal(0n)
+    expect(stats!.settledTradeCount).to.equal(0n)
   })
 })

--- a/tests/trade_reversions.test.ts
+++ b/tests/trade_reversions.test.ts
@@ -105,9 +105,9 @@ describe('onTradeReversion', () => {
       volumeInOwl: 1337n * 2000n,
       utilityInOwl: 42n,
       owlBurnt: 1337n,
-      settledBatchCount: 1n,
-      settledTradeCount: 1n,
-      listedTokens: 2n,
+      settledBatchCount: 1,
+      settledTradeCount: 1,
+      listedTokens: 2,
     })
 
     mappings.onTradeReversion(
@@ -191,7 +191,7 @@ describe('onTradeReversion', () => {
     expect(stats!.volumeInOwl).to.equal(0n)
     expect(stats!.utilityInOwl).to.equal(0n)
     expect(stats!.owlBurnt).to.equal(0n)
-    expect(stats!.settledBatchCount).to.equal(0n)
-    expect(stats!.settledTradeCount).to.equal(0n)
+    expect(stats!.settledBatchCount).to.equal(0)
+    expect(stats!.settledTradeCount).to.equal(0)
   })
 })

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -143,6 +143,15 @@ const EntityDefinitions = {
     txHash: Store.ValueKind.Bytes,
     txLogIndex: Store.ValueKind.BigInt,
   },
+  Stats: {
+    id: Store.ValueKind.String,
+    volumeInOwl: Store.ValueKind.BigInt,
+    utilityInOwl: Store.ValueKind.BigInt,
+    owlBurnt: Store.ValueKind.BigInt,
+    settledBatchCount: Store.ValueKind.BigInt,
+    settledTradeCount: Store.ValueKind.BigInt,
+    listedTokens: Store.ValueKind.BigInt,
+  },
   Token: {
     id: Store.ValueKind.String,
     address: Store.ValueKind.Bytes,

--- a/tests/wasm/definitions.ts
+++ b/tests/wasm/definitions.ts
@@ -148,9 +148,9 @@ const EntityDefinitions = {
     volumeInOwl: Store.ValueKind.BigInt,
     utilityInOwl: Store.ValueKind.BigInt,
     owlBurnt: Store.ValueKind.BigInt,
-    settledBatchCount: Store.ValueKind.BigInt,
-    settledTradeCount: Store.ValueKind.BigInt,
-    listedTokens: Store.ValueKind.BigInt,
+    settledBatchCount: Store.ValueKind.Int,
+    settledTradeCount: Store.ValueKind.Int,
+    listedTokens: Store.ValueKind.Int,
   },
   Token: {
     id: Store.ValueKind.String,


### PR DESCRIPTION
This PR adds a stats entity which allows us to record metrics like total volume, fees, number of trades, batches, etc. I got inspired by our top level dune metrics which we should now be able to answer e.g. for xdai using the graph.

<img width="1330" alt="Screenshot 2020-11-05 at 19 51 09" src="https://user-images.githubusercontent.com/1200333/98283664-44892880-1fa0-11eb-96d8-85c61938470c.png">


### Test Plan

Added unit and e2e tests